### PR TITLE
Fix Var Warnings

### DIFF
--- a/src/external/FlashStorage/FlashStorage.cpp
+++ b/src/external/FlashStorage/FlashStorage.cpp
@@ -16,88 +16,97 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#if defined (ARDUINO_SAMD_ZERO)
+#if defined(ARDUINO_SAMD_ZERO)
 
 #include "FlashStorage.h"
 
-static const uint32_t pageSizes[] = { 8, 16, 32, 64, 128, 256, 512, 1024 };
+static const uint32_t pageSizes[] = {8, 16, 32, 64, 128, 256, 512, 1024};
 
-FlashClass::FlashClass(const void *flash_addr, uint32_t size) :
-  PAGE_SIZE(pageSizes[NVMCTRL->PARAM.bit.PSZ]),
-  PAGES(NVMCTRL->PARAM.bit.NVMP),
-  MAX_FLASH(PAGE_SIZE * PAGES),
-  ROW_SIZE(PAGE_SIZE * 4),
-  flash_address((volatile void *)flash_addr),
-  flash_size(size)
+FlashClass::FlashClass(const void *flash_addr, uint32_t size) : PAGE_SIZE(pageSizes[NVMCTRL->PARAM.bit.PSZ]),
+                                                                PAGES(NVMCTRL->PARAM.bit.NVMP),
+                                                                MAX_FLASH(PAGE_SIZE * PAGES),
+                                                                ROW_SIZE(PAGE_SIZE * 4),
+                                                                flash_address((volatile void *)flash_addr),
+                                                                flash_size(size)
 {
 }
 
 static inline uint32_t read_unaligned_uint32(const void *data)
 {
-  union {
-    uint32_t u32;
-    uint8_t u8[4];
-  } res;
-  const uint8_t *d = (const uint8_t *)data;
-  res.u8[0] = d[0];
-  res.u8[1] = d[1];
-  res.u8[2] = d[2];
-  res.u8[3] = d[3];
-  return res.u32;
+    union
+    {
+        uint32_t u32;
+        uint8_t u8[4];
+    } res;
+    const uint8_t *d = (const uint8_t *)data;
+    res.u8[0] = d[0];
+    res.u8[1] = d[1];
+    res.u8[2] = d[2];
+    res.u8[3] = d[3];
+    return res.u32;
 }
 
 void FlashClass::write(const volatile void *flash_ptr, const void *data, uint32_t size)
 {
-  // Calculate data boundaries
-  size = (size + 3) / 4;
-  volatile uint32_t *dst_addr = (volatile uint32_t *)flash_ptr;
-  const uint8_t *src_addr = (uint8_t *)data;
+    // Calculate data boundaries
+    size = (size + 3) / 4;
+    volatile uint32_t *dst_addr = (volatile uint32_t *)flash_ptr;
+    const uint8_t *src_addr = (uint8_t *)data;
 
-  // Disable automatic page write
-  NVMCTRL->CTRLB.bit.MANW = 1;
+    // Disable automatic page write
+    NVMCTRL->CTRLB.bit.MANW = 1;
 
-  // Do writes in pages
-  while (size) {
-    // Execute "PBC" Page Buffer Clear
-    NVMCTRL->CTRLA.reg = NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_PBC;
-    while (NVMCTRL->INTFLAG.bit.READY == 0) { }
+    // Do writes in pages
+    while (size)
+    {
+        // Execute "PBC" Page Buffer Clear
+        NVMCTRL->CTRLA.reg = NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_PBC;
+        while (NVMCTRL->INTFLAG.bit.READY == 0)
+        {
+        }
 
-    // Fill page buffer
-    uint32_t i;
-    for (i=0; i<(PAGE_SIZE/4) && size; i++) {
-      *dst_addr = read_unaligned_uint32(src_addr);
-      src_addr += 4;
-      dst_addr++;
-      size--;
+        // Fill page buffer
+        uint32_t i;
+        for (i = 0; i < (PAGE_SIZE / 4) && size; i++)
+        {
+            *dst_addr = read_unaligned_uint32(src_addr);
+            src_addr += 4;
+            dst_addr++;
+            size--;
+        }
+
+        // Execute "WP" Write Page
+        NVMCTRL->CTRLA.reg = NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP;
+        while (NVMCTRL->INTFLAG.bit.READY == 0)
+        {
+        }
     }
-
-    // Execute "WP" Write Page
-    NVMCTRL->CTRLA.reg = NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP;
-    while (NVMCTRL->INTFLAG.bit.READY == 0) { }
-  }
 }
 
 void FlashClass::erase(const volatile void *flash_ptr, uint32_t size)
 {
-  const uint8_t *ptr = (const uint8_t *)flash_ptr;
-  while (size > ROW_SIZE) {
+    const uint8_t *ptr = (const uint8_t *)flash_ptr;
+    while (size > ROW_SIZE)
+    {
+        erase(ptr);
+        ptr += ROW_SIZE;
+        size -= ROW_SIZE;
+    }
     erase(ptr);
-    ptr += ROW_SIZE;
-    size -= ROW_SIZE;
-  }
-  erase(ptr);
 }
 
 void FlashClass::erase(const volatile void *flash_ptr)
 {
-  NVMCTRL->ADDR.reg = ((uint32_t)flash_ptr) / 2;
-  NVMCTRL->CTRLA.reg = NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_ER;
-  while (!NVMCTRL->INTFLAG.bit.READY) { }
+    NVMCTRL->ADDR.reg = ((uint32_t)flash_ptr) / 2;
+    NVMCTRL->CTRLA.reg = NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_ER;
+    while (!NVMCTRL->INTFLAG.bit.READY)
+    {
+    }
 }
 
 void FlashClass::read(const volatile void *flash_ptr, void *data, uint32_t size)
 {
-  memcpy(data, (const void *)flash_ptr, size);
+    memcpy(data, (const void *)flash_ptr, size);
 }
 
-#endif  // defined (ARDUINO_SAMD_ZERO)
+#endif // defined (ARDUINO_SAMD_ZERO)

--- a/src/external/FlashStorage/FlashStorage.h
+++ b/src/external/FlashStorage/FlashStorage.h
@@ -21,56 +21,64 @@
 #include <Arduino.h>
 
 // Concatenate after macro expansion
-#define PPCAT_NX(A, B) A ## B
+#define PPCAT_NX(A, B) A##B
 #define PPCAT(A, B) PPCAT_NX(A, B)
 
-#define Flash(name, size) \
-  __attribute__((__aligned__(256))) \
-  static const uint8_t PPCAT(_data,name)[(size+255)/256*256] = { }; \
-  FlashClass name(PPCAT(_data,name), size);
+#define Flash(name, size)                                                                                     \
+    __attribute__((__aligned__(256))) static const uint8_t PPCAT(_data, name)[(size + 255) / 256 * 256] = {}; \
+    FlashClass name(PPCAT(_data, name), size);
 
-#define FlashStorage(name, T) \
-  __attribute__((__aligned__(256))) \
-  static const uint8_t PPCAT(_data,name)[(sizeof(T)+255)/256*256] = { }; \
-  FlashStorageClass<T> name(PPCAT(_data,name));
+#define FlashStorage(name, T)                                                                                      \
+    __attribute__((__aligned__(256))) static const uint8_t PPCAT(_data, name)[(sizeof(T) + 255) / 256 * 256] = {}; \
+    FlashStorageClass<T> name(PPCAT(_data, name));
 
-class FlashClass {
+class FlashClass
+{
 public:
-  FlashClass(const void *flash_addr = NULL, uint32_t size = 0);
+    FlashClass(const void *flash_addr = NULL, uint32_t size = 0);
 
-  void write(const void *data) { write(flash_address, data, flash_size); }
-  void erase()                 { erase(flash_address, flash_size);       }
-  void read(void *data)        { read(flash_address, data, flash_size);  }
+    void write(const void *data) { write(flash_address, data, flash_size); }
+    void erase() { erase(flash_address, flash_size); }
+    void read(void *data) { read(flash_address, data, flash_size); }
 
-  void write(const volatile void *flash_ptr, const void *data, uint32_t size);
-  void erase(const volatile void *flash_ptr, uint32_t size);
-  void read(const volatile void *flash_ptr, void *data, uint32_t size);
+    void write(const volatile void *flash_ptr, const void *data, uint32_t size);
+    void erase(const volatile void *flash_ptr, uint32_t size);
+    void read(const volatile void *flash_ptr, void *data, uint32_t size);
 
 private:
-  void erase(const volatile void *flash_ptr);
+    void erase(const volatile void *flash_ptr);
 
-  const uint32_t PAGE_SIZE, PAGES, MAX_FLASH, ROW_SIZE;
-  const volatile void *flash_address;
-  const uint32_t flash_size;
+    const uint32_t PAGE_SIZE, PAGES, MAX_FLASH, ROW_SIZE;
+    const volatile void *flash_address;
+    const uint32_t flash_size;
 };
 
-template<class T>
-class FlashStorageClass {
+template <class T>
+class FlashStorageClass
+{
 public:
-  FlashStorageClass(const void *flash_addr) : flash(flash_addr, sizeof(T)) { };
+    FlashStorageClass(const void *flash_addr) : flash(flash_addr, sizeof(T)){};
 
-  // Write data into flash memory.
-  // Compiler is able to optimize parameter copy.
-  inline void write(T data)  { flash.erase(); flash.write(&data); }
+    // Write data into flash memory.
+    // Compiler is able to optimize parameter copy.
+    inline void write(T data)
+    {
+        flash.erase();
+        flash.write(&data);
+    }
 
-  // Read data from flash into variable.
-  inline void read(T *data)  { flash.read(data); }
+    // Read data from flash into variable.
+    inline void read(T *data) { flash.read(data); }
 
-  // Overloaded version of read.
-  // Compiler is able to optimize copy-on-return.
-  inline T read() { T data; read(&data); return data; }
+    // Overloaded version of read.
+    // Compiler is able to optimize copy-on-return.
+    inline T read()
+    {
+        T data;
+        read(&data);
+        return data;
+    }
 
 private:
-  FlashClass flash;
+    FlashClass flash;
 };
-

--- a/src/internal/ConnectionClient.h
+++ b/src/internal/ConnectionClient.h
@@ -1,7 +1,6 @@
 #ifndef __CONNECTION_CLIENT_H__
 #define __CONNECTION_CLIENT_H__
 
-
 #include <Arduino.h>
 
 #ifdef ARDUINO_SAMD_ZERO

--- a/src/internal/ParseClient.h
+++ b/src/internal/ParseClient.h
@@ -36,44 +36,44 @@
 /*! \class ParseClient
  *  \brief Class responsible for Parse connection
  */
-class ParseClient {
+class ParseClient
+{
 private:
-  char applicationId[41]; // APPLICATION_ID_MAX_LEN
-  char clientKey[41]; // CLIENT_KEY_MAX_LEN
-  char serverURL[100]; // SERVER_URL_MAX_LEN
-  char hostFingerprint[100]; // HOST_FINGERPRINT_MAX_LEN
-  char installationId[37]; // INSTALLATION_ID_MAX_LEN
-  char sessionToken[41]; // SESSION_TOKEN_MAX_LEN
+    char applicationId[41];    // APPLICATION_ID_MAX_LEN
+    char clientKey[41];        // CLIENT_KEY_MAX_LEN
+    char serverURL[100];       // SERVER_URL_MAX_LEN
+    char hostFingerprint[100]; // HOST_FINGERPRINT_MAX_LEN
+    char installationId[37];   // INSTALLATION_ID_MAX_LEN
+    char sessionToken[41];     // SESSION_TOKEN_MAX_LEN
 
-  ConnectionClient client;
-  ConnectionClient pushClient;
+    ConnectionClient client;
+    ConnectionClient pushClient;
 
-  unsigned long lastHeartbeat;
+    unsigned long lastHeartbeat;
 
-  void read(ConnectionClient* client, char* buf, int len);
+    void read(ConnectionClient *client, char *buf, int len);
 
-#if defined (ARDUINO_SAMD_ZERO) || defined(ARDUINO_ARCH_ESP8266)
-  char lastPushTime[41]; // PUSH_TIME_MAX_LEN
-  bool dataIsDirty;
-  char pushBuff[5];
+#if defined(ARDUINO_SAMD_ZERO) || defined(ARDUINO_ARCH_ESP8266)
+    char lastPushTime[41]; // PUSH_TIME_MAX_LEN
+    bool dataIsDirty;
+    char pushBuff[5];
 
-  void saveKeys();
-  void restoreKeys();
-  void saveLastPushTime(char *time);
+    void saveKeys();
+    void restoreKeys();
+    void saveLastPushTime(char *time);
 #endif
 
 public:
-  /*! \fn ParseClient()
+    /*! \fn ParseClient()
    *  \brief Constructor of ParseClient object
    */
-  ParseClient();
-  /*! \fn ParseClient()
+    ParseClient();
+    /*! \fn ParseClient()
    *  \brief Destructor of ParseClient object
    */
-  ~ParseClient();
+    ~ParseClient();
 
-
-  /*! \fn begin(const char *applicationId, const char *clientKey)
+    /*! \fn begin(const char *applicationId, const char *clientKey)
    *  \brief Initialize the Parse client and user session
    *
    *  This method only initializes the Parse client, used for subsequent API requests. It does
@@ -82,9 +82,9 @@ public:
    *  \param applicationId The application id for the Parse application. (required)
    *  \param clientKey     The client API key for the Parse application. (required)
    */
-  void begin(const char *applicationId, const char *clientKey);
+    void begin(const char *applicationId, const char *clientKey);
 
-  /*! \fn void setServerURL(const char *serverURL)
+    /*! \fn void setServerURL(const char *serverURL)
    *  \brief Set the installation object id for this client.
    *
    *  Set the custom server url for this client. This needs to be called
@@ -93,8 +93,8 @@ public:
    *  \param  serverURL     The server URL to which client should connect.
    *
    */
-  void setServerURL(const char *serverURL);
-  
+    void setServerURL(const char *serverURL);
+
     /*! \fn void setHostFingerprint(const char *hostFingerprint)
    *  \brief Set the host fingerprint this client.
    *
@@ -104,17 +104,17 @@ public:
    *  \param  hostFingerprint     The host fingerprint of the serverURL.
    *
    */
-  void setHostFingerprint(const char *hostFingerprint);
-  
+    void setHostFingerprint(const char *hostFingerprint);
+
     /*! \fn setClientInsecure()
    *  \brief Sets the connection client to insecure
    *
    *  
    *
    */
-  void setClientInsecure();
+    void setClientInsecure();
 
-  /*! \fn void setInstallationId(const char *installationId)
+    /*! \fn void setInstallationId(const char *installationId)
    *  \brief Set the installation object id for this client.
    *
    *  Set the installation object id for this client. If this is not called before making an
@@ -124,9 +124,9 @@ public:
    *  \param  installationId   The installation id to be used by the client.
    *
    */
-  void setInstallationId(const char *installationId);
+    void setInstallationId(const char *installationId);
 
-  /*! \fn const char * getInstallationId()
+    /*! \fn const char * getInstallationId()
    *  \brief Return the client installation id
    *
    *  Return the installation id for the client. If called before the installation id for the
@@ -145,9 +145,9 @@ public:
    *  \result                      The instalaltion id.
    *
    */
-  const char* getInstallationId();
+    const char *getInstallationId();
 
-  /*! \fn void setSessionToken(const char *sessionToken)
+    /*! \fn void setSessionToken(const char *sessionToken)
    *  \brief Set the session token for the Parse client
    *
    *  \param  sessionToken     The new session token. All subsequent API calls will
@@ -155,26 +155,26 @@ public:
    *                           If this is NULL, the client will be unauthenticated.
    *
    */
-  void setSessionToken(const char* sessionToken);
+    void setSessionToken(const char *sessionToken);
 
-  /*! \fn void clearSessionToken()
+    /*! \fn void clearSessionToken()
    *  \brief Clear the session token
    *
    *  Same as setSessionToken(NULL);
    *
    */
-  void clearSessionToken();
+    void clearSessionToken();
 
-  /*! \fn const char *getSessionToken()
+    /*! \fn const char *getSessionToken()
    *  \brief Return the client session token.
    *
    *  Return the session token for the client, or NULL if there isn't one.
    *
    *  \result                  The session token.
    */
-  const char* getSessionToken();
+    const char *getSessionToken();
 
-  /*! \fn ParseResponse sendRequest(const char* httpVerb, const char* httpPath, const char* requestBody, const char* urlParams)
+    /*! \fn ParseResponse sendRequest(const char* httpVerb, const char* httpPath, const char* requestBody, const char* urlParams)
    *  \brief Directly call REST API in Parse.
    *
    *  \param   httpVerb - GET/DELETE/PUT/POST
@@ -186,9 +186,9 @@ public:
    *  NOTE: ParseObjectCreate, ParseObjectUpdate, ParseObjectDelete, ParseGETObject,
    *  ParseQuery, ParseCloudFunction, ParseTrackEvent can also be used for REST API call
    */
-  ParseResponse sendRequest(const char* httpVerb, const char* httpPath, const char* requestBody, const char* urlParams);
+    ParseResponse sendRequest(const char *httpVerb, const char *httpPath, const char *requestBody, const char *urlParams);
 
-  /*! \fn ParseResponse sendRequest(const String& httpVerb, const String& httpPath, const String& requestBody, const String& urlParams)
+    /*! \fn ParseResponse sendRequest(const String& httpVerb, const String& httpPath, const String& requestBody, const String& urlParams)
    *  \brief Directly call REST API in Parse.
    *
    *  \param   httpVerb - GET/DELETE/PUT/POST
@@ -200,9 +200,9 @@ public:
    *  NOTE: ParseObjectCreate, ParseObjectUpdate, ParseObjectDelete, ParseGETObject,
    *  ParseQuery, ParseCloudFunction, ParseTrackEvent can also be used for REST API call
    */
-  ParseResponse sendRequest(const String& httpVerb, const String& httpPath, const String& requestBody, const String& urlParams);
+    ParseResponse sendRequest(const String &httpVerb, const String &httpPath, const String &requestBody, const String &urlParams);
 
-  /*! \fn int startPushService()
+    /*! \fn int startPushService()
    *  \brief Start the push notifications service.
    *
    *  This method will start the push notification service and will listen for incoming
@@ -220,41 +220,41 @@ public:
    *  \result                    false if the push can't be started or true if
    *                             started successfully.
    */
-  bool startPushService();
+    bool startPushService();
 
-  /*! \fn void stopPushService()
+    /*! \fn void stopPushService()
    *  \brief Stop the push notifications service.
    *
    *  This method will stop the push notification service. If the push service is not started,
    *  this will do nothing.
    */
-  void stopPushService();
+    void stopPushService();
 
-  /*! \fn bool pushAvailable()
+    /*! \fn bool pushAvailable()
    *  \brief Check if there is any new push message.
    *
    *  use only after startPushService()
    *
    *  \result                    true if there is a push message, false otherwise.
    */
-  bool pushAvailable();
+    bool pushAvailable();
 
-  /*! \fn ParsePush nextPush()
+    /*! \fn ParsePush nextPush()
    *  \brief Get next push message.
    *
    *  NOTE: use only when pushAvailable() is TRUE
    *
    *  \result                    a ParsePush instance which contains one or multiple push messages
    */
-  ParsePush nextPush();
+    ParsePush nextPush();
 
-  /*! \fn void end()
+    /*! \fn void end()
    *  \brief Release resource.
    */
-  void end();
+    void end();
 
-  friend class ParseResponse;
-  friend class ParsePush;
+    friend class ParseResponse;
+    friend class ParsePush;
 };
 
 /*! \var Parse

--- a/src/internal/ParseCloudFunction.cpp
+++ b/src/internal/ParseCloudFunction.cpp
@@ -21,10 +21,12 @@
 
 #include "ParseCloudFunction.h"
 
-ParseCloudFunction::ParseCloudFunction() : ParseObjectCreate() {
+ParseCloudFunction::ParseCloudFunction() : ParseObjectCreate()
+{
 }
 
-void ParseCloudFunction::setFunctionName(const char* function) {
-	httpPath += "/functions/";
-	httpPath += function;
+void ParseCloudFunction::setFunctionName(const char *function)
+{
+    httpPath += "/functions/";
+    httpPath += function;
 }

--- a/src/internal/ParseCloudFunction.h
+++ b/src/internal/ParseCloudFunction.h
@@ -32,19 +32,20 @@
 /*! \class ParseCloudFunction
  *  \brief Class responsible for cloud function
  */
-class ParseCloudFunction : public ParseObjectCreate {
+class ParseCloudFunction : public ParseObjectCreate
+{
 public:
-  /*! \fn ParseCloudFunction()
+    /*! \fn ParseCloudFunction()
    *  \brief Constructor of ParseCloudFunction object
    */
-  ParseCloudFunction();
+    ParseCloudFunction();
 
-  /*! \fn void setFunctionName(const char* function)
+    /*! \fn void setFunctionName(const char* function)
    *  \brief Set the cloud funciton name to be called.
    *
    *  \param function Function name
    */
-  void setFunctionName(const char* function);
+    void setFunctionName(const char *function);
 };
 
 #endif

--- a/src/internal/ParseObjectCreate.cpp
+++ b/src/internal/ParseObjectCreate.cpp
@@ -23,78 +23,95 @@
 #include "ParseClient.h"
 #include "ParseObjectCreate.h"
 
-void ParseObjectCreate::addKey(const char* key) {
-	if (isBodySet) {
-		return;
-	}
-	if (!requestBody.equals("{")) {
-		requestBody += ",";
-	}
-	requestBody += "\"";
-	requestBody += key;
-	requestBody += "\"";
-	requestBody += ":";
+void ParseObjectCreate::addKey(const char *key)
+{
+    if (isBodySet)
+    {
+        return;
+    }
+    if (!requestBody.equals("{"))
+    {
+        requestBody += ",";
+    }
+    requestBody += "\"";
+    requestBody += key;
+    requestBody += "\"";
+    requestBody += ":";
 }
 
-void ParseObjectCreate::add(const char* key, int d) {
-	addKey(key);
-	requestBody += d;
+void ParseObjectCreate::add(const char *key, int d)
+{
+    addKey(key);
+    requestBody += d;
 }
 
-void ParseObjectCreate::add(const char* key, double d) {
-	addKey(key);
-	requestBody += d;
+void ParseObjectCreate::add(const char *key, double d)
+{
+    addKey(key);
+    requestBody += d;
 }
 
-void ParseObjectCreate::add(const char* key, bool b) {
-	addKey(key);
-	if(b) {
-		requestBody += "true";
-	} else {
-		requestBody += "false";
-	}
+void ParseObjectCreate::add(const char *key, bool b)
+{
+    addKey(key);
+    if (b)
+    {
+        requestBody += "true";
+    }
+    else
+    {
+        requestBody += "false";
+    }
 }
 
-void ParseObjectCreate::add(const char* key, const char* s) {
-	addKey(key);
-	requestBody += "\"";
-	requestBody += s;
-	requestBody += "\"";
+void ParseObjectCreate::add(const char *key, const char *s)
+{
+    addKey(key);
+    requestBody += "\"";
+    requestBody += s;
+    requestBody += "\"";
 }
 
-void ParseObjectCreate::addGeoPoint(const char* key, double lat, double lon) {
-	addKey(key);
-	String geoPoint = "{\"__type\":\"GeoPoint\",\"latitude\":";
-	geoPoint += lat;
-	geoPoint += ",\"longitude\":";
-	geoPoint += lon;
-	geoPoint += "}";
-  requestBody += geoPoint;
+void ParseObjectCreate::addGeoPoint(const char *key, double lat, double lon)
+{
+    addKey(key);
+    String geoPoint = "{\"__type\":\"GeoPoint\",\"latitude\":";
+    geoPoint += lat;
+    geoPoint += ",\"longitude\":";
+    geoPoint += lon;
+    geoPoint += "}";
+    requestBody += geoPoint;
 }
 
-void ParseObjectCreate::addJSONValue(const char* key, const char* json) {
-	addKey(key);
-	requestBody += json;
+void ParseObjectCreate::addJSONValue(const char *key, const char *json)
+{
+    addKey(key);
+    requestBody += json;
 }
 
-void ParseObjectCreate::addJSONValue(const char* key, const String& json) {
-	addKey(key);
-	requestBody += json;
+void ParseObjectCreate::addJSONValue(const char *key, const String &json)
+{
+    addKey(key);
+    requestBody += json;
 }
 
-void ParseObjectCreate::setJSONBody(const char* jsonBody) {
-	requestBody = jsonBody;
-	isBodySet = true;
+void ParseObjectCreate::setJSONBody(const char *jsonBody)
+{
+    requestBody = jsonBody;
+    isBodySet = true;
 }
 
-void ParseObjectCreate::setJSONBody(const String& jsonBody) {
-	requestBody = jsonBody;
-	isBodySet = true;
+void ParseObjectCreate::setJSONBody(const String &jsonBody)
+{
+    requestBody = jsonBody;
+    isBodySet = true;
 }
 
-ParseResponse ParseObjectCreate::send() {
-	if (!isBodySet) {
-		requestBody += "}";
-	}
-	return Parse.sendRequest("POST", httpPath, requestBody, "");
+ParseResponse ParseObjectCreate::send()
+{
+    if (!isBodySet)
+    {
+        requestBody += "}";
+    }
+    return Parse.sendRequest("POST", httpPath, requestBody, "");
 }

--- a/src/internal/ParseObjectCreate.h
+++ b/src/internal/ParseObjectCreate.h
@@ -32,93 +32,95 @@
 /*! \class ParseObjectCreate
  *  \brief Class responsible for new Parse object creation
  */
-class ParseObjectCreate : public ParseRequest {
+class ParseObjectCreate : public ParseRequest
+{
 protected:
-	void addKey(const char* key);
+    void addKey(const char *key);
+
 public:
-  /*! \fn ParseObjectCreate()
+    /*! \fn ParseObjectCreate()
    *  \brief Constructor of ParseObjectCreate object
    */
-  ParseObjectCreate() : ParseRequest() {}
+    ParseObjectCreate() : ParseRequest() {}
 
-  /*! \fn void add(const char* key, int d)
+    /*! \fn void add(const char* key, int d)
    *  \brief Add a key and integer value pair to object.
    *
    *  \param key The key name.
    *  \param d   The value.
    */
-  void add(const char* key, int d);
+    void add(const char *key, int d);
 
-  /*! \fn void add(const char* key, double d)
+    /*! \fn void add(const char* key, double d)
    *  \brief Add a key and double value pair to object.
    *
    *  \param key The key name.
    *  \param d   The value.
    */
-  void add(const char* key, double d);
+    void add(const char *key, double d);
 
-  /*! \fn add(const char* key, const char* s)
+    /*! \fn add(const char* key, const char* s)
    *  \brief add a key and string value pair to object.
    *
    *  \param key The key name.
    *  \param s   The value.
    */
-  void add(const char* key, const char* s);
+    void add(const char *key, const char *s);
 
-  /*! \fn void add(const char* key, bool b)
+    /*! \fn void add(const char* key, bool b)
    *  \brief add a key and boolean value pair to object.
    *
    *  \param key The key name.
    *  \param b   The value.
    */
-  void add(const char* key, bool b);
+    void add(const char *key, bool b);
 
-  /*! \fn void addGeoPoint(const char* key, double lat, double lon)
+    /*! \fn void addGeoPoint(const char* key, double lat, double lon)
    *  \brief add a key and GeoPoint value pair to object.
    *
    *  \param key The key name.
    *  \param lat The latitude value.
    *  \param lon The logitude value.
    */
-  void addGeoPoint(const char* key, double lat, double lon);
+    void addGeoPoint(const char *key, double lat, double lon);
 
-  /*! \fn void addJSONValue(const char* key, const char* json)
+    /*! \fn void addJSONValue(const char* key, const char* json)
    *  \brief add a key and json value pair to object.
    *
    *  \param key  The key name.
    *  \param json The value.
    */
-  void addJSONValue(const char* key, const char* json);
+    void addJSONValue(const char *key, const char *json);
 
-  /*! \fn void addJSONValue(const char* key, const String& json)
+    /*! \fn void addJSONValue(const char* key, const String& json)
    *  \brief add a key and json value pair to object.
    *
    *  \param key  The key name.
    *  \param json The value.
    */
-  void addJSONValue(const char* key, const String& json);
+    void addJSONValue(const char *key, const String &json);
 
-  /*! \fn void setJSONBody(const char* jsonBody)
+    /*! \fn void setJSONBody(const char* jsonBody)
    *  \brief set the json body of object directly.
    *
    *  NOTE: this will remove all previous key-value pairs set if there are any
    *  \param jsonBody The new JSON body.
    */
-  void setJSONBody(const char* jsonBody);
+    void setJSONBody(const char *jsonBody);
 
-  /*! \fn void setJSONBody(const String& jsonBody)
+    /*! \fn void setJSONBody(const String& jsonBody)
    *  \brief set the json body of object directly.
    *
    *  NOTE: this will remove all previous key-value pairs set if there are any
    *  \param jsonBody The new JSON body.
    */
-  void setJSONBody(const String& jsonBody);
+    void setJSONBody(const String &jsonBody);
 
-  /*! \fn virtual ParseResponse send()
+    /*! \fn virtual ParseResponse send()
    *  \brief launch the object creation request and execute.
    *
    */
-  virtual ParseResponse send();
+    virtual ParseResponse send();
 };
 
 #endif

--- a/src/internal/ParseObjectDelete.cpp
+++ b/src/internal/ParseObjectDelete.cpp
@@ -23,9 +23,11 @@
 #include "ParseClient.h"
 #include "ParseObjectDelete.h"
 
-ParseObjectDelete::ParseObjectDelete() : ParseRequest() {
+ParseObjectDelete::ParseObjectDelete() : ParseRequest()
+{
 }
 
-ParseResponse ParseObjectDelete::send() {
-	return Parse.sendRequest("DELETE", httpPath, "", "");
+ParseResponse ParseObjectDelete::send()
+{
+    return Parse.sendRequest("DELETE", httpPath, "", "");
 }

--- a/src/internal/ParseObjectDelete.h
+++ b/src/internal/ParseObjectDelete.h
@@ -32,19 +32,20 @@
 /*! \class ParseObjectDelete
  *  \brief Class responsible for object deletion.
  */
-class ParseObjectDelete : public ParseRequest {
+class ParseObjectDelete : public ParseRequest
+{
 public:
-  /*! \fn ParseObjectDelete()
+    /*! \fn ParseObjectDelete()
    *  \brief Constructor of ParseObjectDelete object
    */
-  ParseObjectDelete();
+    ParseObjectDelete();
 
-  /*! \fn ParseResponse send() override
+    /*! \fn ParseResponse send() override
    *  \brief launch the object deletion request and execute.
    *
    *  \return  response of request.
    */
-  ParseResponse send();
+    ParseResponse send();
 };
 
 #endif

--- a/src/internal/ParseObjectGet.cpp
+++ b/src/internal/ParseObjectGet.cpp
@@ -23,9 +23,11 @@
 #include "ParseClient.h"
 #include "ParseObjectGet.h"
 
-ParseObjectGet::ParseObjectGet() : ParseRequest() {
+ParseObjectGet::ParseObjectGet() : ParseRequest()
+{
 }
 
-ParseResponse ParseObjectGet::send() {
-	return Parse.sendRequest("GET", httpPath, "", "");
+ParseResponse ParseObjectGet::send()
+{
+    return Parse.sendRequest("GET", httpPath, "", "");
 }

--- a/src/internal/ParseObjectGet.h
+++ b/src/internal/ParseObjectGet.h
@@ -32,19 +32,20 @@
 /*! \class ParseObjectGet()
  *  \brief Class responsible for getting the object from Parse.
  */
-class ParseObjectGet : public ParseRequest {
+class ParseObjectGet : public ParseRequest
+{
 public:
-  /*! \fn ParseObjectGet()
+    /*! \fn ParseObjectGet()
    *  \brief Constructor of ParseObjectGet object
    */
-  ParseObjectGet();
+    ParseObjectGet();
 
-  /*! \fn ParseResponse send() override
+    /*! \fn ParseResponse send() override
    *  \brief launch the get object request and execute.
    *
    *  \result response of request
    */
-  ParseResponse send();
+    ParseResponse send();
 };
 
 #endif

--- a/src/internal/ParseObjectUpdate.cpp
+++ b/src/internal/ParseObjectUpdate.cpp
@@ -23,14 +23,16 @@
 #include "ParseClient.h"
 #include "ParseObjectUpdate.h"
 
-ParseObjectUpdate::ParseObjectUpdate() : ParseObjectCreate() {
+ParseObjectUpdate::ParseObjectUpdate() : ParseObjectCreate()
+{
 }
 
+ParseResponse ParseObjectUpdate::send()
+{
+    if (!isBodySet)
+    {
+        requestBody += "}";
+    }
 
-ParseResponse ParseObjectUpdate::send() {
-	if (!isBodySet) {
-		requestBody += "}";
-	}
-
-	return Parse.sendRequest("PUT", httpPath, requestBody, "");
+    return Parse.sendRequest("PUT", httpPath, requestBody, "");
 }

--- a/src/internal/ParseObjectUpdate.h
+++ b/src/internal/ParseObjectUpdate.h
@@ -32,19 +32,20 @@
 /*! \class ParseObjectUpdate
  *  \brief Class responsible for object update
  */
-class ParseObjectUpdate : public ParseObjectCreate {
+class ParseObjectUpdate : public ParseObjectCreate
+{
 public:
-  /*! \fn ParseObjectUpdate()
+    /*! \fn ParseObjectUpdate()
    *  \brief Constructor of ParseObjectUpdate object
    */
-  ParseObjectUpdate();
+    ParseObjectUpdate();
 
-  /*! \fn ParseResponse send() override
+    /*! \fn ParseResponse send() override
    *  \brief launch the update object request and execute.
    *
    *  \result the response
    */
-  ParseResponse send();
+    ParseResponse send();
 };
 
 #endif

--- a/src/internal/ParsePlatformSupport.h
+++ b/src/internal/ParsePlatformSupport.h
@@ -4,9 +4,10 @@
 #include <Arduino.h>
 #include "ConnectionClient.h"
 
-class ParsePlatformSupport {
+class ParsePlatformSupport
+{
 public:
-    static int read(ConnectionClient* client, char* buf, int len);
+    static int read(ConnectionClient *client, char *buf, int len);
 };
 
 #endif //__PARSE_PLATFORM_SUPPORT_H__

--- a/src/internal/ParsePush.h
+++ b/src/internal/ParsePush.h
@@ -33,25 +33,25 @@
 /*! \class ParsePush
  *  \brief Class with a push. Not created directly.
  */
-class ParsePush : public ParseResponse {
+class ParsePush : public ParseResponse
+{
 protected:
-  ParsePush(ConnectionClient* pushClient);
+    ParsePush(ConnectionClient *pushClient);
 
-#if defined (ARDUINO_SAMD_ZERO) || defined(ARDUINO_ARCH_ESP8266)
-  char lookahead[5];
-  void setLookahead(const char *read_data);
-  void read();
-#endif  // defined (ARDUINO_SAMD_ZERO)
+#if defined(ARDUINO_SAMD_ZERO) || defined(ARDUINO_ARCH_ESP8266)
+    char lookahead[5];
+    void setLookahead(const char *read_data);
+    void read();
+#endif // defined (ARDUINO_SAMD_ZERO)
 
 public:
-
-  /*! \fn void close()
+    /*! \fn void close()
    *  \brief free resource including data buffer.
    *
    */
-  void close();
+    void close();
 
-  friend class ParseClient;
+    friend class ParseClient;
 };
 
 #endif

--- a/src/internal/ParseQuery.cpp
+++ b/src/internal/ParseQuery.cpp
@@ -23,7 +23,8 @@
 #include "ParseClient.h"
 #include "ParseQuery.h"
 
-ParseQuery::ParseQuery() : ParseRequest() {
+ParseQuery::ParseQuery() : ParseRequest()
+{
 	whereClause = "";
 	limit = -1;
 	skip = -1;
@@ -31,15 +32,20 @@ ParseQuery::ParseQuery() : ParseRequest() {
 	returnedFields = "";
 }
 
-long getDecimal(double v) {
-  long decimal = 1000 * (v - int(v));
-  return decimal > 0 ? decimal : -1 * decimal;
+long getDecimal(double v)
+{
+	long decimal = 1000 * (v - int(v));
+	return decimal > 0 ? decimal : -1 * decimal;
 }
 
-void ParseQuery::addConditionKey(const char* key) {
-	if (whereClause == "") {
+void ParseQuery::addConditionKey(const char *key)
+{
+	if (whereClause == "")
+	{
 		whereClause += "{";
-	} else {
+	}
+	else
+	{
 		whereClause += ",";
 	}
 
@@ -49,13 +55,17 @@ void ParseQuery::addConditionKey(const char* key) {
 	whereClause += ":";
 }
 
-void ParseQuery::addConditionNum(const char* key, const char* comparator, double v) {
+void ParseQuery::addConditionNum(const char *key, const char *comparator, double v)
+{
 	addConditionKey(key);
-  String stringVal = String(int(v)) + "." + String(getDecimal(v));
+	String stringVal = String(int(v)) + "." + String(getDecimal(v));
 
-	if (comparator == "$=") {
+	if (strcmp(comparator, "$=") == 0)
+	{
 		whereClause += stringVal;
-	} else {
+	}
+	else
+	{
 		whereClause += "{\"";
 		whereClause += comparator;
 		whereClause += "\":";
@@ -64,130 +74,157 @@ void ParseQuery::addConditionNum(const char* key, const char* comparator, double
 	}
 }
 
-void ParseQuery::whereExists(const char* key) {
+void ParseQuery::whereExists(const char *key)
+{
 	addConditionKey(key);
 	whereClause += "{\"exists\":true}";
 }
 
-void ParseQuery::whereDoesNotExist(const char* key) {
+void ParseQuery::whereDoesNotExist(const char *key)
+{
 	addConditionKey(key);
 	whereClause += "{\"exists\":false}";
 }
 
-void ParseQuery::whereEqualTo(const char* key, const char* v) {
+void ParseQuery::whereEqualTo(const char *key, const char *v)
+{
 	addConditionKey(key);
 	whereClause += "\"";
 	whereClause += v;
 	whereClause += "\"";
 }
 
-void ParseQuery::whereNotEqualTo(const char* key, const char* v) {
+void ParseQuery::whereNotEqualTo(const char *key, const char *v)
+{
 	addConditionKey(key);
 	whereClause += "{\"$ne\":\"";
 	whereClause += v;
 	whereClause += "\"}";
 }
 
-void ParseQuery::whereEqualTo(const char* key, bool v) {
+void ParseQuery::whereEqualTo(const char *key, bool v)
+{
 	addConditionKey(key);
-	whereClause += v?"true":"false";
+	whereClause += v ? "true" : "false";
 }
 
-void ParseQuery::whereNotEqualTo(const char* key, bool v) {
+void ParseQuery::whereNotEqualTo(const char *key, bool v)
+{
 	addConditionKey(key);
 	whereClause += "{\"$ne\":";
-	whereClause += v?"true":"false";
+	whereClause += v ? "true" : "false";
 	whereClause += "}";
 }
 
-void ParseQuery::whereEqualTo(const char* key, int v) {
+void ParseQuery::whereEqualTo(const char *key, int v)
+{
 	addConditionNum(key, "$=", v);
 }
 
-void ParseQuery::whereNotEqualTo(const char* key, int v) {
+void ParseQuery::whereNotEqualTo(const char *key, int v)
+{
 	addConditionNum(key, "$ne", v);
 }
 
-void ParseQuery::whereLessThan(const char* key, int v) {
+void ParseQuery::whereLessThan(const char *key, int v)
+{
 	addConditionNum(key, "$lt", v);
 }
 
-void ParseQuery::whereGreaterThan(const char* key, int v) {
+void ParseQuery::whereGreaterThan(const char *key, int v)
+{
 	addConditionNum(key, "$gt", v);
 }
 
-void ParseQuery::whereLessThanOrEqualTo(const char* key, int v) {
+void ParseQuery::whereLessThanOrEqualTo(const char *key, int v)
+{
 	addConditionNum(key, "$lte", v);
 }
 
-void ParseQuery::whereGreaterThanOrEqualTo(const char* key, int v) {
+void ParseQuery::whereGreaterThanOrEqualTo(const char *key, int v)
+{
 	addConditionNum(key, "$gte", v);
 }
 
-void ParseQuery::whereEqualTo(const char* key, double v) {
+void ParseQuery::whereEqualTo(const char *key, double v)
+{
 	addConditionNum(key, "$=", v);
 }
 
-void ParseQuery::whereNotEqualTo(const char* key, double v) {
+void ParseQuery::whereNotEqualTo(const char *key, double v)
+{
 	addConditionNum(key, "$ne", v);
 }
 
-void ParseQuery::whereLessThan(const char* key, double v) {
+void ParseQuery::whereLessThan(const char *key, double v)
+{
 	addConditionNum(key, "$lt", v);
 }
 
-void ParseQuery::whereGreaterThan(const char* key, double v) {
+void ParseQuery::whereGreaterThan(const char *key, double v)
+{
 	addConditionNum(key, "$gt", v);
 }
 
-void ParseQuery::whereLessThanOrEqualTo(const char* key, double v) {
+void ParseQuery::whereLessThanOrEqualTo(const char *key, double v)
+{
 	addConditionNum(key, "$lte", v);
 }
 
-void ParseQuery::whereGreaterThanOrEqualTo(const char* key, double v) {
+void ParseQuery::whereGreaterThanOrEqualTo(const char *key, double v)
+{
 	addConditionNum(key, "$gte", v);
 }
 
-void ParseQuery::setLimit(int n) {
+void ParseQuery::setLimit(int n)
+{
 	limit = n;
 }
 
-void ParseQuery::setSkip(int n) {
+void ParseQuery::setSkip(int n)
+{
 	skip = n;
 }
 
-void ParseQuery::orderBy(const char* key) {
+void ParseQuery::orderBy(const char *key)
+{
 	order = key;
 }
 
-void ParseQuery::setKeys(const char* keys) {
+void ParseQuery::setKeys(const char *keys)
+{
 	returnedFields = keys;
 }
 
-ParseResponse ParseQuery::send() {
-  String urlParameters = "";
-  if (whereClause != "") {
-    whereClause += "}"; // close where clause if there is any
-    urlParameters += "where=";
-    urlParameters += whereClause;
-  } 
-  
-	if (limit>0) {
+ParseResponse ParseQuery::send()
+{
+	String urlParameters = "";
+	if (whereClause != "")
+	{
+		whereClause += "}"; // close where clause if there is any
+		urlParameters += "where=";
+		urlParameters += whereClause;
+	}
+
+	if (limit > 0)
+	{
 		urlParameters += "&limit=";
 		urlParameters += limit;
 	}
-	if (skip>0) {
+	if (skip > 0)
+	{
 		urlParameters += "&skip=";
 		urlParameters += skip;
 	}
-	if (order != "") {
+	if (order != "")
+	{
 		urlParameters += "&order=";
 		urlParameters += order;
 	}
-	if (returnedFields != "") {
+	if (returnedFields != "")
+	{
 		urlParameters += "&keys=";
 		urlParameters += returnedFields;
 	}
 	return Parse.sendRequest("GET", httpPath, "", urlParameters);
 }
-

--- a/src/internal/ParseQuery.cpp
+++ b/src/internal/ParseQuery.cpp
@@ -25,206 +25,206 @@
 
 ParseQuery::ParseQuery() : ParseRequest()
 {
-	whereClause = "";
-	limit = -1;
-	skip = -1;
-	order = "";
-	returnedFields = "";
+    whereClause = "";
+    limit = -1;
+    skip = -1;
+    order = "";
+    returnedFields = "";
 }
 
 long getDecimal(double v)
 {
-	long decimal = 1000 * (v - int(v));
-	return decimal > 0 ? decimal : -1 * decimal;
+    long decimal = 1000 * (v - int(v));
+    return decimal > 0 ? decimal : -1 * decimal;
 }
 
 void ParseQuery::addConditionKey(const char *key)
 {
-	if (whereClause == "")
-	{
-		whereClause += "{";
-	}
-	else
-	{
-		whereClause += ",";
-	}
+    if (whereClause == "")
+    {
+        whereClause += "{";
+    }
+    else
+    {
+        whereClause += ",";
+    }
 
-	whereClause += "\"";
-	whereClause += key;
-	whereClause += "\"";
-	whereClause += ":";
+    whereClause += "\"";
+    whereClause += key;
+    whereClause += "\"";
+    whereClause += ":";
 }
 
 void ParseQuery::addConditionNum(const char *key, const char *comparator, double v)
 {
-	addConditionKey(key);
-	String stringVal = String(int(v)) + "." + String(getDecimal(v));
+    addConditionKey(key);
+    String stringVal = String(int(v)) + "." + String(getDecimal(v));
 
-	if (strcmp(comparator, "$=") == 0)
-	{
-		whereClause += stringVal;
-	}
-	else
-	{
-		whereClause += "{\"";
-		whereClause += comparator;
-		whereClause += "\":";
-		whereClause += stringVal;
-		whereClause += "}";
-	}
+    if (strcmp(comparator, "$=") == 0)
+    {
+        whereClause += stringVal;
+    }
+    else
+    {
+        whereClause += "{\"";
+        whereClause += comparator;
+        whereClause += "\":";
+        whereClause += stringVal;
+        whereClause += "}";
+    }
 }
 
 void ParseQuery::whereExists(const char *key)
 {
-	addConditionKey(key);
-	whereClause += "{\"exists\":true}";
+    addConditionKey(key);
+    whereClause += "{\"exists\":true}";
 }
 
 void ParseQuery::whereDoesNotExist(const char *key)
 {
-	addConditionKey(key);
-	whereClause += "{\"exists\":false}";
+    addConditionKey(key);
+    whereClause += "{\"exists\":false}";
 }
 
 void ParseQuery::whereEqualTo(const char *key, const char *v)
 {
-	addConditionKey(key);
-	whereClause += "\"";
-	whereClause += v;
-	whereClause += "\"";
+    addConditionKey(key);
+    whereClause += "\"";
+    whereClause += v;
+    whereClause += "\"";
 }
 
 void ParseQuery::whereNotEqualTo(const char *key, const char *v)
 {
-	addConditionKey(key);
-	whereClause += "{\"$ne\":\"";
-	whereClause += v;
-	whereClause += "\"}";
+    addConditionKey(key);
+    whereClause += "{\"$ne\":\"";
+    whereClause += v;
+    whereClause += "\"}";
 }
 
 void ParseQuery::whereEqualTo(const char *key, bool v)
 {
-	addConditionKey(key);
-	whereClause += v ? "true" : "false";
+    addConditionKey(key);
+    whereClause += v ? "true" : "false";
 }
 
 void ParseQuery::whereNotEqualTo(const char *key, bool v)
 {
-	addConditionKey(key);
-	whereClause += "{\"$ne\":";
-	whereClause += v ? "true" : "false";
-	whereClause += "}";
+    addConditionKey(key);
+    whereClause += "{\"$ne\":";
+    whereClause += v ? "true" : "false";
+    whereClause += "}";
 }
 
 void ParseQuery::whereEqualTo(const char *key, int v)
 {
-	addConditionNum(key, "$=", v);
+    addConditionNum(key, "$=", v);
 }
 
 void ParseQuery::whereNotEqualTo(const char *key, int v)
 {
-	addConditionNum(key, "$ne", v);
+    addConditionNum(key, "$ne", v);
 }
 
 void ParseQuery::whereLessThan(const char *key, int v)
 {
-	addConditionNum(key, "$lt", v);
+    addConditionNum(key, "$lt", v);
 }
 
 void ParseQuery::whereGreaterThan(const char *key, int v)
 {
-	addConditionNum(key, "$gt", v);
+    addConditionNum(key, "$gt", v);
 }
 
 void ParseQuery::whereLessThanOrEqualTo(const char *key, int v)
 {
-	addConditionNum(key, "$lte", v);
+    addConditionNum(key, "$lte", v);
 }
 
 void ParseQuery::whereGreaterThanOrEqualTo(const char *key, int v)
 {
-	addConditionNum(key, "$gte", v);
+    addConditionNum(key, "$gte", v);
 }
 
 void ParseQuery::whereEqualTo(const char *key, double v)
 {
-	addConditionNum(key, "$=", v);
+    addConditionNum(key, "$=", v);
 }
 
 void ParseQuery::whereNotEqualTo(const char *key, double v)
 {
-	addConditionNum(key, "$ne", v);
+    addConditionNum(key, "$ne", v);
 }
 
 void ParseQuery::whereLessThan(const char *key, double v)
 {
-	addConditionNum(key, "$lt", v);
+    addConditionNum(key, "$lt", v);
 }
 
 void ParseQuery::whereGreaterThan(const char *key, double v)
 {
-	addConditionNum(key, "$gt", v);
+    addConditionNum(key, "$gt", v);
 }
 
 void ParseQuery::whereLessThanOrEqualTo(const char *key, double v)
 {
-	addConditionNum(key, "$lte", v);
+    addConditionNum(key, "$lte", v);
 }
 
 void ParseQuery::whereGreaterThanOrEqualTo(const char *key, double v)
 {
-	addConditionNum(key, "$gte", v);
+    addConditionNum(key, "$gte", v);
 }
 
 void ParseQuery::setLimit(int n)
 {
-	limit = n;
+    limit = n;
 }
 
 void ParseQuery::setSkip(int n)
 {
-	skip = n;
+    skip = n;
 }
 
 void ParseQuery::orderBy(const char *key)
 {
-	order = key;
+    order = key;
 }
 
 void ParseQuery::setKeys(const char *keys)
 {
-	returnedFields = keys;
+    returnedFields = keys;
 }
 
 ParseResponse ParseQuery::send()
 {
-	String urlParameters = "";
-	if (whereClause != "")
-	{
-		whereClause += "}"; // close where clause if there is any
-		urlParameters += "where=";
-		urlParameters += whereClause;
-	}
+    String urlParameters = "";
+    if (whereClause != "")
+    {
+        whereClause += "}"; // close where clause if there is any
+        urlParameters += "where=";
+        urlParameters += whereClause;
+    }
 
-	if (limit > 0)
-	{
-		urlParameters += "&limit=";
-		urlParameters += limit;
-	}
-	if (skip > 0)
-	{
-		urlParameters += "&skip=";
-		urlParameters += skip;
-	}
-	if (order != "")
-	{
-		urlParameters += "&order=";
-		urlParameters += order;
-	}
-	if (returnedFields != "")
-	{
-		urlParameters += "&keys=";
-		urlParameters += returnedFields;
-	}
-	return Parse.sendRequest("GET", httpPath, "", urlParameters);
+    if (limit > 0)
+    {
+        urlParameters += "&limit=";
+        urlParameters += limit;
+    }
+    if (skip > 0)
+    {
+        urlParameters += "&skip=";
+        urlParameters += skip;
+    }
+    if (order != "")
+    {
+        urlParameters += "&order=";
+        urlParameters += order;
+    }
+    if (returnedFields != "")
+    {
+        urlParameters += "&keys=";
+        urlParameters += returnedFields;
+    }
+    return Parse.sendRequest("GET", httpPath, "", urlParameters);
 }

--- a/src/internal/ParseQuery.h
+++ b/src/internal/ParseQuery.h
@@ -32,172 +32,174 @@
 /*! \class ParseQuery
  *  \brief Class responsible for query encapsulation
  */
-class ParseQuery : public ParseRequest {
+class ParseQuery : public ParseRequest
+{
 private:
-	String whereClause;
-	String order;
-	String returnedFields;
-	int limit;
-	int skip;
-	void addConditionKey(const char* key);
-	void addConditionNum(const char* key, const char* comparator, double value);
+    String whereClause;
+    String order;
+    String returnedFields;
+    int limit;
+    int skip;
+    void addConditionKey(const char *key);
+    void addConditionNum(const char *key, const char *comparator, double value);
+
 public:
-  /*! \fn ParseQuery()
+    /*! \fn ParseQuery()
    *  \brief Constructor of ParseCloudFunction object
    */
-  ParseQuery();
+    ParseQuery();
 
-  /*! \fn void whereExists(const char* key)
+    /*! \fn void whereExists(const char* key)
    *  \brief Add a constraint for finding objects that contain the given key.
    *
    *  \param key - the key that should exist.
    */
-  void whereExists(const char* key);
+    void whereExists(const char *key);
 
-  /*! \fn void whereDoesNotExist(const char* key)
+    /*! \fn void whereDoesNotExist(const char* key)
    *  \brief add a constraint for finding objects that does not contain the given key.
    *
    *  \param key - the key that should not exist.
    */
-  void whereDoesNotExist(const char* key);
+    void whereDoesNotExist(const char *key);
 
-  /*** string condition ***/
+    /*** string condition ***/
 
-  /*! \fn void whereEqualTo(const char* key, const char* value)
+    /*! \fn void whereEqualTo(const char* key, const char* value)
    *  \brief add a constraint to the query that requires a particular key's value to be equal to the provided string value.
    *
    *  \param key - The key to check.
    *  \param value - The value that the ParseObject must contain.
    */
-  void whereEqualTo(const char* key, const char* value);
+    void whereEqualTo(const char *key, const char *value);
 
-  /*! \fn void whereNotEqualTo(const char* key, const char* value)
+    /*! \fn void whereNotEqualTo(const char* key, const char* value)
    *  \brief add a constraint to the query that requires a particular key's value not equal to the provided string value.
    *
    *  \param key - The key to check.
    *  \param value - The value that must not be equalled.
    */
-  void whereNotEqualTo(const char* key, const char* value);
+    void whereNotEqualTo(const char *key, const char *value);
 
-  /*** boolean condition ***/
+    /*** boolean condition ***/
 
-  /*! \fn void whereEqualTo(const char* key, bool value)
+    /*! \fn void whereEqualTo(const char* key, bool value)
    *  \brief add a constraint to the query that requires a particular key's value to be equal to the provided boolean value.
    *
    *  \param key - The key to check.
    *  \param value - The value that the ParseObject must contain.
    */
-  void whereEqualTo(const char* key, bool value);
+    void whereEqualTo(const char *key, bool value);
 
-  /*! \fn void whereNotEqualTo(const char* key, bool value)
+    /*! \fn void whereNotEqualTo(const char* key, bool value)
    *  \brief add a constraint to the query that requires a particular key's value to be equal to the provided string value.
    *
    *  \param key - The key to check.
    *  \param value - The value that must not be equalled.
    */
-  void whereNotEqualTo(const char* key, bool value);
+    void whereNotEqualTo(const char *key, bool value);
 
-  /*** integer number condition ***/
+    /*** integer number condition ***/
 
-  /*! \fn void whereEqualTo(const char* key, int value)
+    /*! \fn void whereEqualTo(const char* key, int value)
    *  \brief add a constraint to the query that requires a particular key's value to be equal to the provided string value.
    *
    *  \param key - The key to check.
    *  \param value - The value that the ParseObject must contain.
    */
-  void whereEqualTo(const char* key, int value);
+    void whereEqualTo(const char *key, int value);
 
-  /*! \fn void whereNotEqualTo(const char* key, int value)
+    /*! \fn void whereNotEqualTo(const char* key, int value)
    *  \brief add a constraint to the query that requires a particular key's value to be equal to the provided string value.
    *
    *  \param key - The key to check.
    *  \param value - The value that must not be equalled.
    */
-  void whereNotEqualTo(const char* key, int value);
+    void whereNotEqualTo(const char *key, int value);
 
-  /*! \fn void whereLessThan(const char* key, int value)
+    /*! \fn void whereLessThan(const char* key, int value)
    *  \brief add a constraint to the query that requires a particular key's value to be less than the provided value.
    *
    *  \param key - The key to check.
    *  \param value - The value that provides an upper bound.
    */
-  void whereLessThan(const char* key, int value);
+    void whereLessThan(const char *key, int value);
 
-  /*! \fn void whereGreaterThan(const char* key, int value)
+    /*! \fn void whereGreaterThan(const char* key, int value)
    *  \brief add a constraint to the query that requires a particular key's value to be greater than the provided value.
    *
    *  \param key - The key to check.
    *  \param value - The value that provides an lower bound.
    */
-  void whereGreaterThan(const char* key, int value);
+    void whereGreaterThan(const char *key, int value);
 
-  /*! \fn void whereLessThanOrEqualTo(const char* key, int value)
+    /*! \fn void whereLessThanOrEqualTo(const char* key, int value)
    *  \brief add a constraint to the query that requires a particular key's value to be less than or equal to the provided value.
    *
    *  \param key - The key to check.
    *  \param value - The value that provides an upper bound.
    */
-  void whereLessThanOrEqualTo(const char* key, int value);
+    void whereLessThanOrEqualTo(const char *key, int value);
 
-  /*! \fn void whereGreaterThanOrEqualTo(const char* key, int value)
+    /*! \fn void whereGreaterThanOrEqualTo(const char* key, int value)
    *  \brief add a constraint to the query that requires a particular key's value to be greater than or equal to the provided value.
    *
    *  \param key - The key to check.
    *  \param value - The value that provides an lower bound.
    */
-  void whereGreaterThanOrEqualTo(const char* key, int value);
+    void whereGreaterThanOrEqualTo(const char *key, int value);
 
-  /*** double number condition ***/
+    /*** double number condition ***/
 
-  /*! \fn void whereEqualTo(const char* key, double value)
+    /*! \fn void whereEqualTo(const char* key, double value)
    *  \brief add a constraint to the query that requires a particular key's value to be equal to the provided value.
    *
    *  \param key - The key to check.
    *  \param value - The value that the ParseObject must contain.
    */
-  void whereEqualTo(const char* key, double value);
+    void whereEqualTo(const char *key, double value);
 
-  /*! \fn void whereNotEqualTo(const char* key, double value)
+    /*! \fn void whereNotEqualTo(const char* key, double value)
    *  \brief add a constraint to the query that requires a particular key's value not equal to the provided double value.
    *
    *  \param key - The key to check.
    *  \param value - The value that must not be equalled.
    */
-  void whereNotEqualTo(const char* key, double value);
+    void whereNotEqualTo(const char *key, double value);
 
-  /*! \fn void whereLessThan(const char* key, double value)
+    /*! \fn void whereLessThan(const char* key, double value)
    *  \brief add a constraint to the query that requires a particular key's value to be less than the provided value.
    *
    *  \param key - The key to check.
    *  \param value - The value that provides an upper bound.
    */
-  void whereLessThan(const char* key, double value);
+    void whereLessThan(const char *key, double value);
 
-  /*! \fn void whereGreaterThan(const char* key, double value)
+    /*! \fn void whereGreaterThan(const char* key, double value)
    *  \brief add a constraint to the query that requires a particular key's value to be greater than the provided value.
    *
    *  \param key - The key to check.
    *  \param value - The value that provides an lower bound.
    */
-  void whereGreaterThan(const char* key, double value);
+    void whereGreaterThan(const char *key, double value);
 
-  /*! \fn void whereLessThanOrEqualTo(const char* key, double value)
+    /*! \fn void whereLessThanOrEqualTo(const char* key, double value)
    *  \brief add a constraint to the query that requires a particular key's value to be less than or equal to the provided value.
    *
    *  \param key - The key to check.
    *  \param value - The value that provides an upper bound.
    */
-  void whereLessThanOrEqualTo(const char* key, double value);
+    void whereLessThanOrEqualTo(const char *key, double value);
 
-  /*! \fn void whereGreaterThanOrEqualTo(const char* key, double value)
+    /*! \fn void whereGreaterThanOrEqualTo(const char* key, double value)
    *  \brief add a constraint to the query that requires a particular key's value to be greater than or equal to the provided value.
    *
    *  \param key - The key to check.
    *  \param value - The value that provides an lower bound.
    */
-  void whereGreaterThanOrEqualTo(const char* key, double value);
+    void whereGreaterThanOrEqualTo(const char *key, double value);
 
-  /*! \fn void setLimit(int n)
+    /*! \fn void setLimit(int n)
    *  \brief controls the maximum number of results that are returned.
    *
    *  controls the maximum number of results that are returned.
@@ -206,24 +208,24 @@ public:
    *
    *  \param n - limit.
    */
-  void setLimit(int n);
+    void setLimit(int n);
 
-  /*! \fn void setSkip(int n)
+    /*! \fn void setSkip(int n)
    *  \brief controls the number of results to skip before returning any results.
    *
    *  \param n - number to skip.
    */
-  void setSkip(int n);
+    void setSkip(int n);
 
-  /*! \fn void setKeys(const char* keys)
+    /*! \fn void setKeys(const char* keys)
    *  \brief restrict the fields of returned ParseObjects to only include the provided keys.
    *
    *  \param keys - Keys to include. seperate multiple keys with comma
    *                e.g. "score,name"
    */
-  void setKeys(const char* keys);
+    void setKeys(const char *keys);
 
-  /*! \fn void orderBy(const char* key)
+    /*! \fn void orderBy(const char* key)
    *  \brief sorts the results in ascending/descending order by the given key.
    *
    *  \param keys - Keys to sort on.
@@ -231,14 +233,14 @@ public:
    *                use a negative sign "-field_name" for descending order
    *                seperate multiple keys with comma e.g.  "score,-name"
    */
-  void orderBy(const char* keys);
+    void orderBy(const char *keys);
 
-  /*! \fn ParseResponse send() override
+    /*! \fn ParseResponse send() override
    *  \brief launch query and execute
    *
    *  \result response of the request.
    */
-  ParseResponse send();
+    ParseResponse send();
 };
 
 #endif

--- a/src/internal/ParseRequest.cpp
+++ b/src/internal/ParseRequest.cpp
@@ -22,28 +22,39 @@
 #include "ParseInternal.h"
 #include "ParseRequest.h"
 
-ParseRequest::ParseRequest() {
+ParseRequest::ParseRequest()
+{
 	requestBody = "{";
 	httpPath = "/";
 	isBodySet = false;
 }
 
-ParseRequest::~ParseRequest() {
+ParseRequest::~ParseRequest()
+{
 }
 
-void ParseRequest::setObjectId(const char* key) {
+void ParseRequest::setObjectId(const char *key)
+{
 	httpPath += "/";
 	httpPath += key;
 }
 
-void ParseRequest::setClassName(const char* className) {
-	if (className == "_User") {
+void ParseRequest::setClassName(const char *className)
+{
+	if (strcmp(className, "_User") == 0)
+	{
 		httpPath += "users";
-	} else if (className == "_Installation") {
+	}
+	else if (strcmp(className, "_Installation") == 0)
+	{
 		httpPath += "installations";
-	} else if (className == "_Role") {
+	}
+	else if (strcmp(className, "_Role") == 0)
+	{
 		httpPath += "roles";
-	} else {
+	}
+	else
+	{
 		httpPath += "classes/";
 		httpPath += className;
 	}

--- a/src/internal/ParseRequest.cpp
+++ b/src/internal/ParseRequest.cpp
@@ -24,9 +24,9 @@
 
 ParseRequest::ParseRequest()
 {
-	requestBody = "{";
-	httpPath = "/";
-	isBodySet = false;
+    requestBody = "{";
+    httpPath = "/";
+    isBodySet = false;
 }
 
 ParseRequest::~ParseRequest()
@@ -35,27 +35,27 @@ ParseRequest::~ParseRequest()
 
 void ParseRequest::setObjectId(const char *key)
 {
-	httpPath += "/";
-	httpPath += key;
+    httpPath += "/";
+    httpPath += key;
 }
 
 void ParseRequest::setClassName(const char *className)
 {
-	if (strcmp(className, "_User") == 0)
-	{
-		httpPath += "users";
-	}
-	else if (strcmp(className, "_Installation") == 0)
-	{
-		httpPath += "installations";
-	}
-	else if (strcmp(className, "_Role") == 0)
-	{
-		httpPath += "roles";
-	}
-	else
-	{
-		httpPath += "classes/";
-		httpPath += className;
-	}
+    if (strcmp(className, "_User") == 0)
+    {
+        httpPath += "users";
+    }
+    else if (strcmp(className, "_Installation") == 0)
+    {
+        httpPath += "installations";
+    }
+    else if (strcmp(className, "_Role") == 0)
+    {
+        httpPath += "roles";
+    }
+    else
+    {
+        httpPath += "classes/";
+        httpPath += className;
+    }
 }

--- a/src/internal/ParseRequest.h
+++ b/src/internal/ParseRequest.h
@@ -33,23 +33,25 @@
 /*! \class ParseRequest
  *  \brief Class responsible for Parse requests
  */
-class ParseRequest {
+class ParseRequest
+{
 protected:
-	String httpPath;
-	String requestBody;
-	bool isBodySet;
+    String httpPath;
+    String requestBody;
+    bool isBodySet;
+
 public:
-  /*! \fn ParseRequest()
+    /*! \fn ParseRequest()
    *  \brief Constructor of ParseRequest object
    */
-  ParseRequest();
+    ParseRequest();
 
-  /*! \fn ~ParseRequest()
+    /*! \fn ~ParseRequest()
    *  \brief Destructor of ParseRequest object
    */
-  ~ParseRequest();
+    ~ParseRequest();
 
-  /*! \fn void setClassName(const char* className)
+    /*! \fn void setClassName(const char* className)
    *  \brief set the ParseObject class name in which request will be performed.
    *
    * NOTE: ONLY use when request(GET/UPDATE/DELETE/CREATE/QUERY) is related with object
@@ -59,9 +61,9 @@ public:
    *
    *  \param className class name.
    */
-  void setClassName(const char* className);
+    void setClassName(const char *className);
 
-  /*! \fn void setObjectId(const char* objectId)
+    /*! \fn void setObjectId(const char* objectId)
    *  \brief set the ParseObject object id in which request will be performed.
    *
    * NOTE: ONLY setObjectId for GET/UPDATE/DELETE request on a specific object
@@ -69,14 +71,14 @@ public:
    *
    *  \param objectId object id.
    */
-  void setObjectId(const char* objectId);
+    void setObjectId(const char *objectId);
 
-  /*! \fn virtual ParseResponse send()
+    /*! \fn virtual ParseResponse send()
    *  \brief execute the parse request.
    *
    *  \result response of request
    */
-  virtual ParseResponse send() = 0;
+    virtual ParseResponse send() = 0;
 };
 
 #endif

--- a/src/internal/ParseResponse.h
+++ b/src/internal/ParseResponse.h
@@ -33,50 +33,51 @@
  *  \brief Class that encapsulates Rest API response.
  *  This object created indirectly.
  */
-class ParseResponse {
+class ParseResponse
+{
 protected:
-  const static int BUFSIZE = 128;
-  int bufSize;
-  char* buf;
-  char* tmpBuf;
-  bool isUserBuffer;
-  int p;
-  int resultCount;
-#if defined (ARDUINO_SAMD_ZERO) || defined(ARDUINO_ARCH_ESP8266)
-  long responseLength;
-  bool isChunked;
-  bool firstObject;
-  bool dataDone;
-  char chunkedBuffer[1024];
-  int bufferPos;
-  int lastRead;
+    const static int BUFSIZE = 128;
+    int bufSize;
+    char *buf;
+    char *tmpBuf;
+    bool isUserBuffer;
+    int p;
+    int resultCount;
+#if defined(ARDUINO_SAMD_ZERO) || defined(ARDUINO_ARCH_ESP8266)
+    long responseLength;
+    bool isChunked;
+    bool firstObject;
+    bool dataDone;
+    char chunkedBuffer[1024];
+    int bufferPos;
+    int lastRead;
 #endif
-  ConnectionClient* client;
+    ConnectionClient *client;
 
-  virtual void read();
-  void readWithTimeout(int maxSec);
+    virtual void read();
+    void readWithTimeout(int maxSec);
 
-#if defined (ARDUINO_SAMD_ZERO) || defined(ARDUINO_ARCH_ESP8266)
-  // Zero functions only - do nothing on Yun
-  void readLine(char *buff, int sz);
-  bool readJson(char *buff, int sz);
-  bool readJsonInternal(char *buff, int sz, int *read_bytes, char started);
-  int readChunkedData(int timeout);
-  // End Zero only functions
+#if defined(ARDUINO_SAMD_ZERO) || defined(ARDUINO_ARCH_ESP8266)
+    // Zero functions only - do nothing on Yun
+    void readLine(char *buff, int sz);
+    bool readJson(char *buff, int sz);
+    bool readJsonInternal(char *buff, int sz, int *read_bytes, char started);
+    int readChunkedData(int timeout);
+    // End Zero only functions
 #endif
 
-  int available();
-  void freeBuffer();
+    int available();
+    void freeBuffer();
 
-  ParseResponse(ConnectionClient* client);
+    ParseResponse(ConnectionClient *client);
 
 public:
-  /*! \fn ParseResponse()
+    /*! \fn ParseResponse()
    *  \brief Destructor of ParseResponse object
    */
-  ~ParseResponse();
+    ~ParseResponse();
 
-  /*! \fn void setBuffer(char* buffer, int size)
+    /*! \fn void setBuffer(char* buffer, int size)
    *  \brief set the customer buffer for writing response data.
    *
    *  \param buffer - char array buffer
@@ -84,55 +85,55 @@ public:
    *                NOTE: if buffer is not set, a default size of 128
    *                will be initialized.
    */
-  void setBuffer(char* buffer, int size);
+    void setBuffer(char *buffer, int size);
 
-  /*! \fn int getErrorCode()
+    /*! \fn int getErrorCode()
    *  \brief get the "error" field in the response.
    *
    *  \result error_code when error happens, 0 when there is no error
    */
-  int getErrorCode();
+    int getErrorCode();
 
-  /*! \fn int getInt(const char* key)
+    /*! \fn int getInt(const char* key)
    *  \brief get the integer value in the response by key
    *
    *  \param key - key
    *  \result the value
    */
-  int getInt(const char* key);
+    int getInt(const char *key);
 
-  /*! \fn double getDouble(const char* key)
+    /*! \fn double getDouble(const char* key)
    *  \brief get the double value in the response by key.
    *
    *  \param key - key
    *  \result the value
    */
-  double getDouble(const char* key);
+    double getDouble(const char *key);
 
-  /*! \fn bool getBoolean(const char* key)
+    /*! \fn bool getBoolean(const char* key)
    *  \brief get the boolean value in the response by key
    *
    *  \param key - key
    *  \result the value
    */
-  bool getBoolean(const char* key);
+    bool getBoolean(const char *key);
 
-  /*! \fn const char* getString(const char* key)
+    /*! \fn const char* getString(const char* key)
    *  \brief get the string value in the response by key
    *
    *  \param key - key
    *  \result the value
    */
-  const char* getString(const char* key);
+    const char *getString(const char *key);
 
-  /*! \fn const char* getJSONBody()
+    /*! \fn const char* getJSONBody()
    *  \brief get the complete json value of response.
    *
    *  \result returned JSON
    */
-  const char* getJSONBody();
+    const char *getJSONBody();
 
-  /*! \fn bool nextObject()
+    /*! \fn bool nextObject()
    *  \brief ParseQuery ONLY: iterate to next object in query result
    *
    *  it has to be called before any object opreation(getInt/String/Double)
@@ -140,9 +141,9 @@ public:
    *  \result  true if successfully iterate to next object
    *           false if there is no more object
    */
-  bool nextObject();
+    bool nextObject();
 
-  /*! \fn int count()
+    /*! \fn int count()
    *  \brief ParseQuery ONLY: get the count of the objects in query results
    *
    *  NOTE: if the query resutls exceed 2048 bytes(query result buffer size),
@@ -153,17 +154,17 @@ public:
    *        (usually 4K-16K)
    *  \result number of objects in the result
    */
-  int count();
+    int count();
 
-  /*! \fn void close()
+    /*! \fn void close()
    *  \brief free resource including system data buffer and client
    *
    *  NOTE: the customer buffer will NOT be freed, you need
    *        to free them by yourself
    */
-  void close();
+    void close();
 
-  friend class ParseClient;
+    friend class ParseClient;
 };
 
 #endif

--- a/src/internal/ParseTrackEvent.cpp
+++ b/src/internal/ParseTrackEvent.cpp
@@ -22,10 +22,12 @@
 #include "ParseInternal.h"
 #include "ParseTrackEvent.h"
 
-ParseTrackEvent::ParseTrackEvent() : ParseObjectCreate() {
+ParseTrackEvent::ParseTrackEvent() : ParseObjectCreate()
+{
 }
 
-void ParseTrackEvent::setEventName(const char* eventName) {
-  httpPath += "/events/";
-  httpPath += eventName;
+void ParseTrackEvent::setEventName(const char *eventName)
+{
+    httpPath += "/events/";
+    httpPath += eventName;
 }

--- a/src/internal/ParseTrackEvent.h
+++ b/src/internal/ParseTrackEvent.h
@@ -32,19 +32,20 @@
 /*! \class ParseTrackEvent
  *  \brief Class responsible for tracking an event.
  */
-class ParseTrackEvent : public ParseObjectCreate {
+class ParseTrackEvent : public ParseObjectCreate
+{
 public:
-  /*! \fn ParseTrackEvent()
+    /*! \fn ParseTrackEvent()
    *  \brief Constructor of ParseTrackEvent object
    */
-  ParseTrackEvent();
+    ParseTrackEvent();
 
-  /*! \fn void setEventName(const char* eventName)
+    /*! \fn void setEventName(const char* eventName)
    *  \brief set the track event name, which will be available in Parse Analytics
    *
    *  \param eventName event name.
    */
-  void setEventName(const char* eventName);
+    void setEventName(const char *eventName);
 };
 
 #endif

--- a/src/internal/ParseUtils.h
+++ b/src/internal/ParseUtils.h
@@ -30,9 +30,10 @@
 /*! \class ParseUtils
  *  \brief Utility class.
  */
-class ParseUtils {
+class ParseUtils
+{
 public:
-  /*! \fn static int getStringFromJSON(const char* data, const char *key, char* value, int size)
+    /*! \fn static int getStringFromJSON(const char* data, const char *key, char* value, int size)
    *  \brief A very lightweight JSON parser to get the string value by key
    *
    *  \param data - JSON string to parse
@@ -41,211 +42,251 @@ public:
    *  \param size - size of the return buffer
    *  \result 1 if found 0 otherwise
    */
-  static int getStringFromJSON(const char* data, const char *key, char* value, int size) {
-    const char* found = NULL;
-    int inString = 0;
-    int json = 0;
-    int backslash = 0;
-    int endWithQuote = 1;
-    int keyLen = strlen(key);
-    int escape = 0;
-    int jsonLevel = 0;
-    if (!data || !key || !*key)
-         return 0;
+    static int getStringFromJSON(const char *data, const char *key, char *value, int size)
+    {
+        const char *found = NULL;
+        int inString = 0;
+        int json = 0;
+        int backslash = 0;
+        int endWithQuote = 1;
+        int keyLen = strlen(key);
+        // int escape = 0;
+        int jsonLevel = 0;
+        if (!data || !key || !*key)
+            return 0;
 
-    for (found = data; *found; ++found) {
-      if (strncmp(found, key, keyLen)) {
-        switch (*found) {
-          case '\"':
-          inString = 1 - inString;
-          break;
-          case '\\':
-          if (inString) {
-            if (*(found + 1))
-              ++found;
-          }
-          break;
-          case '{':
-          case '[': // treat array as JSON
-          if (!inString) {
-            ++jsonLevel;
-          }
-          break;
-          case '}':
-          case ']':
-          if (!inString) {
-            --jsonLevel;
-            if (jsonLevel < 0) {
-              // Quit on malformed json
-              return 0;
+        for (found = data; *found; ++found)
+        {
+            if (strncmp(found, key, keyLen))
+            {
+                switch (*found)
+                {
+                case '\"':
+                    inString = 1 - inString;
+                    break;
+                case '\\':
+                    if (inString)
+                    {
+                        if (*(found + 1))
+                            ++found;
+                    }
+                    break;
+                case '{':
+                case '[': // treat array as JSON
+                    if (!inString)
+                    {
+                        ++jsonLevel;
+                    }
+                    break;
+                case '}':
+                case ']':
+                    if (!inString)
+                    {
+                        --jsonLevel;
+                        if (jsonLevel < 0)
+                        {
+                            // Quit on malformed json
+                            return 0;
+                        }
+                    }
+                    break;
+                }
+                continue;
             }
-          }
-          break;
-        }
-        continue;
-      } else if (jsonLevel > 1) {
-        continue;
-      }
-      found += keyLen;
-      if (*found != '\"') {
-        data = found;
-        continue;
-      } else {
-        ++found;
-        for (; *found == ' ' || *found == '\t'; ++found);
-        if (*found != ':') {
-          data = found;
-          continue;
-        }
-        ++found;
-        for (; *found == ' ' || *found == '\t'; ++found);
-        if (*found == '{' || *found == '[') {
-          json = 1;
-          endWithQuote = 0;
-        } else {
-          if (*found != '\"')
-            endWithQuote = 0;
-        }
-        break;
-      }
-    }
-    if (!*found)
-      return 0;
-    if (!value)
-      return 1;
-    if (endWithQuote)
-      ++found;
-    inString = !json;
-    jsonLevel = 0;
-    for (; size > 1 && *found; --size, ++found, ++value) {
-      if (backslash) {
-        backslash = 0;
-        *value = *found;
-        continue;
-      }
-      switch (*found) {
-        case '{':
-        case '[':
-        if (!inString)
-          ++jsonLevel;
-        break;
-        case '}':
-        case ']':
-        if (!endWithQuote) {
-          if (!inString) {
-            if (jsonLevel) {
-              --jsonLevel;
-              if (jsonLevel < 0) {
-                // Quit on malformed json
-                return 0;
-              }
+            else if (jsonLevel > 1)
+            {
+                continue;
             }
-            if (!jsonLevel) {
-              if (json) {
+            found += keyLen;
+            if (*found != '\"')
+            {
+                data = found;
+                continue;
+            }
+            else
+            {
+                ++found;
+                for (; *found == ' ' || *found == '\t'; ++found)
+                    ;
+                if (*found != ':')
+                {
+                    data = found;
+                    continue;
+                }
+                ++found;
+                for (; *found == ' ' || *found == '\t'; ++found)
+                    ;
+                if (*found == '{' || *found == '[')
+                {
+                    json = 1;
+                    endWithQuote = 0;
+                }
+                else
+                {
+                    if (*found != '\"')
+                        endWithQuote = 0;
+                }
+                break;
+            }
+        }
+        if (!*found)
+            return 0;
+        if (!value)
+            return 1;
+        if (endWithQuote)
+            ++found;
+        inString = !json;
+        jsonLevel = 0;
+        for (; size > 1 && *found; --size, ++found, ++value)
+        {
+            if (backslash)
+            {
+                backslash = 0;
                 *value = *found;
-                ++value;
-              }
-              goto RETURN_VALUE;
+                continue;
             }
-            break;
-          }
-          // Fall through
-        } else {
-          // Fall through
+            switch (*found)
+            {
+            case '{':
+            case '[':
+                if (!inString)
+                    ++jsonLevel;
+                break;
+            case '}':
+            case ']':
+                if (!endWithQuote)
+                {
+                    if (!inString)
+                    {
+                        if (jsonLevel)
+                        {
+                            --jsonLevel;
+                            if (jsonLevel < 0)
+                            {
+                                // Quit on malformed json
+                                return 0;
+                            }
+                        }
+                        if (!jsonLevel)
+                        {
+                            if (json)
+                            {
+                                *value = *found;
+                                ++value;
+                            }
+                            goto RETURN_VALUE;
+                        }
+                        break;
+                    }
+                    // Fall through
+                }
+                else
+                {
+                    // Fall through
+                }
+            case '\"':
+            case ',':
+                if (endWithQuote && *found != '\"')
+                    break;
+                if (*found == '\"') //if(!json)
+                    inString = 1 - inString;
+                if (!json)
+                    goto RETURN_VALUE;
+                break;
+            case '\\':
+                backslash = 1;
+                break;
+            }
+            *value = *found;
         }
-        case '\"':
-        case ',':
-        if (endWithQuote && *found != '\"')
-          break;
-        if (*found == '\"') //if(!json)
-          inString = 1 - inString;
-        if (!json)
-          goto RETURN_VALUE;
-        break;
-        case '\\': backslash = 1; break;
-      }
-      *value = *found;
-    }
     RETURN_VALUE:
-    *value = 0;
-    if (!*found) // malformed JSON
-      return 0;
-    return 1;
-  }
+        *value = 0;
+        if (!*found) // malformed JSON
+            return 0;
+        return 1;
+    }
 
-  /*! \fn static int getIntFromJSON(const char* data, const char* key)
+    /*! \fn static int getIntFromJSON(const char* data, const char* key)
    *  \brief A very lightweight JSON parser to get the integer value by key
    *
    * \param data - JSON string to parse
    * \param key - key to find
    * \param value - returned integer value, 0 if key not found
    */
-  static int getIntFromJSON(const char* data, const char* key) {
-    char* value = new char[10];
-    if (ParseUtils::getStringFromJSON(data, key, value, 10)) {
-      String c = value;
-      int v = c.toInt();
-      delete[] value;
-      return  v;
+    static int getIntFromJSON(const char *data, const char *key)
+    {
+        char *value = new char[10];
+        if (ParseUtils::getStringFromJSON(data, key, value, 10))
+        {
+            String c = value;
+            int v = c.toInt();
+            delete[] value;
+            return v;
+        }
+
+        delete[] value;
+        return 0;
     }
 
-    delete[] value;
-    return 0;
-  }
-
-  /*! \fn static double getFloatFromJSON(const char* data, const char* key)
+    /*! \fn static double getFloatFromJSON(const char* data, const char* key)
    *  \brief A very lightweight JSON parser to get the float value by key
    *
    * \param data - JSON string to parse
    * \param key - key to find
    * \param value - returned double value, .0 if key not found
    */
-  static double getFloatFromJSON(const char* data, const char* key) {
-    char* value = new char[10];
-    if (ParseUtils::getStringFromJSON(data, key, value, 10)) {
-      String c = value;
-      double v = c.toFloat();
-      delete[] value;
-      return  v;
+    static double getFloatFromJSON(const char *data, const char *key)
+    {
+        char *value = new char[10];
+        if (ParseUtils::getStringFromJSON(data, key, value, 10))
+        {
+            String c = value;
+            double v = c.toFloat();
+            delete[] value;
+            return v;
+        }
+
+        delete[] value;
+        return .0;
     }
 
-    delete[] value;
-    return .0;
-  }
-
-  /*! \fn static double getFloatFromJSON(const char* data, const char* key)
+    /*! \fn static double getFloatFromJSON(const char* data, const char* key)
    *  \brief A very lightweight JSON parser to get the boolean value by key
    *
    * \param data - JSON string to parse
    * \param key - key to find
    * \param value - returned boolean value. false if key not found
    */
-  static bool getBooleanFromJSON(const char* data, const char* key) {
-    char* value = new char[10];
-    if (ParseUtils::getStringFromJSON(data, key, value, 10)) {
-      String c = value;
-      bool v = (c == "true")?true:false;
-      delete[] value;
-      return v;
-    }
-
-    delete[] value;
-    return false;
-  }
-
-  static bool isSanitizedString(const String& userData) {
-    static char badChars[] = " \t\n\r";
-    int k;
-    int i;
-    for(k = 0; k < userData.length(); k++) {
-      for(i = 0; i < strlen(badChars); i++) {
-        if(userData[k] == badChars[i]){
-          return false;
+    static bool getBooleanFromJSON(const char *data, const char *key)
+    {
+        char *value = new char[10];
+        if (ParseUtils::getStringFromJSON(data, key, value, 10))
+        {
+            String c = value;
+            bool v = (c == "true") ? true : false;
+            delete[] value;
+            return v;
         }
-      }
+
+        delete[] value;
+        return false;
     }
-    return true;
-  }
+
+    static bool isSanitizedString(const String &userData)
+    {
+        static char badChars[] = " \t\n\r";
+        for (unsigned int k = 0; k < userData.length(); k++)
+        {
+            for (size_t i = 0; i < strlen(badChars); i++)
+            {
+                if (userData[k] == badChars[i])
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 };
 
 #endif

--- a/src/internal/esp8266/ParseClient.cpp
+++ b/src/internal/esp8266/ParseClient.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-#if defined (ARDUINO_ARCH_ESP8266)
+#if defined(ARDUINO_ARCH_ESP8266)
 #include "../ParseClient.h"
 //#include "../../external/FlashStorage/FlashStorage.h"
 #include <sys/time.h>
@@ -27,17 +27,18 @@
 // Set DEBUG to true to see serial debug output for the main stages
 // of the Parse client.
 const bool DEBUG = true;
-const char* PARSE_API = "api.parse.com";
-const char* USER_AGENT = "arduino-esp8266.v.1.0.1";
-const char* CLIENT_VERSION = "1.0.3";
-const char* PARSE_PUSH = "push.parse.com";
+const char *PARSE_API = "api.parse.com";
+const char *USER_AGENT = "arduino-esp8266.v.1.0.1";
+const char *CLIENT_VERSION = "1.0.3";
+const char *PARSE_PUSH = "push.parse.com";
 const unsigned short SSL_PORT = 443;
 
-struct KeysInternalStorage {
-  bool assigned;
-  char installationId[37];
-  char sessionToken[41];
-  char lastPushTime[41];
+struct KeysInternalStorage
+{
+    bool assigned;
+    char installationId[37];
+    char sessionToken[41];
+    char lastPushTime[41];
 };
 
 // Reserve a portion of flash memory to store a "KeysInternalStorage" variable
@@ -49,245 +50,293 @@ struct KeysInternalStorage {
  * This function does not conform to RFC 4122, even though it returns
  * a string formatted as an UUID. Do not use this to generate proper UUID!
  */
-static String createNewInstallationId(void) {
-  static bool randInitialized = false;
-  char buff[40];
-
-  if (!randInitialized) {
-     struct timeval tm;
-     gettimeofday(&tm, NULL);
-     // Terrible choice for initialization, prone to collision
-     srand((unsigned)tm.tv_sec + (unsigned)tm.tv_usec);
-     randInitialized = true;
-  }
-
-  snprintf(buff, sizeof(buff),
-    "%1x%1x%1x%1x%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x",
-    rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16,
-    rand()%16, rand()%16, rand()%16, rand()%16,
-    rand()%16, rand()%16, rand()%16, rand()%16,
-    rand()%16, rand()%16, rand()%16, rand()%16,
-    rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16
-  );
-  return String(buff);
-}
-
-static void sendAndEchoToSerial(WiFiClientSecure& client, const char *line) {
-  client.print(line);
-  if (Serial && DEBUG)
-    Serial.print(line);
-}
-
-ParseClient::ParseClient() {
-  memset(applicationId, 0, sizeof(applicationId));
-  memset(clientKey, 0, sizeof(clientKey));
-  memset(serverURL, 0, sizeof(serverURL));
-  memset(hostFingerprint, 0, sizeof(hostFingerprint));
-  memset(installationId, 0, sizeof(installationId));
-  memset(sessionToken, 0, sizeof(sessionToken));
-  memset(lastPushTime, 0, sizeof(lastPushTime));
-  lastHeartbeat = 0;
-  dataIsDirty = false;
-}
-
-ParseClient::~ParseClient() {
-  end();
-}
-
-void ParseClient::begin(const char *applicationId, const char *clientKey) {
-  if (Serial && DEBUG) {
-    Serial.print("begin(");
-    Serial.print(applicationId ? applicationId : "NULL");
-    Serial.print(", ");
-    Serial.print(clientKey ? clientKey : "NULL");
-    Serial.println(")");
-  }
-
-  if(applicationId) {
-    strncpy(this->applicationId, applicationId, sizeof(this->applicationId));
-  }
-  if (clientKey) {
-    strncpy(this->clientKey, clientKey, sizeof(this->clientKey));
-  }
-  restoreKeys();
-}
-
-void ParseClient::setServerURL(const char *serverURL) {
-  Serial.print("setting serverURL(");
-  Serial.print(serverURL ? serverURL : "NULL");
-  Serial.println(")");
-  if(serverURL) {
-    strncpy(this->serverURL, serverURL, sizeof(this->serverURL));
-  }
-}
-
-void ParseClient::setHostFingerprint(const char *hostFingerprint) {
-  Serial.print("setting hostFingerprint(");
-  Serial.print(hostFingerprint ? hostFingerprint : "NULL");
-  Serial.println(")");
-  if(hostFingerprint) {
-    strncpy(this->hostFingerprint, hostFingerprint, sizeof(this->hostFingerprint));
-  }
-}
-
-void ParseClient::setClientInsecure() {
-  Serial.println("setting connection client insecure");
-  client.setInsecure();
-}
-
-void ParseClient::setInstallationId(const char *installationId) {
-  if (installationId) {
-    if (strcmp(this->installationId, installationId))
-      dataIsDirty = true;
-    strncpy(this->installationId, installationId, sizeof(this->installationId));
-  } else {
-    if (this->installationId[0])
-      dataIsDirty = true;
-    strncpy(this->installationId, "", sizeof(this->installationId));
-  }
-}
-
-const char* ParseClient::getInstallationId() {
-  if (!strlen(installationId)) {
-    setInstallationId(createNewInstallationId().c_str());
+static String createNewInstallationId(void)
+{
+    static bool randInitialized = false;
     char buff[40];
 
-    if (Serial && DEBUG) {
-      Serial.print("creating new installationId:");
-      Serial.println(installationId);
+    if (!randInitialized)
+    {
+        struct timeval tm;
+        gettimeofday(&tm, NULL);
+        // Terrible choice for initialization, prone to collision
+        srand((unsigned)tm.tv_sec + (unsigned)tm.tv_usec);
+        randInitialized = true;
     }
 
-    char content[120];
-    snprintf(content, sizeof(content), "{\"installationId\": \"%s\", \"deviceType\": \"embedded\", \"parseVersion\": \"1.0.0\"}", installationId);
-
-    ParseResponse response = sendRequest("POST", "/1/installations", content, "");
-    if (Serial && DEBUG) {
-      Serial.print("response:");
-      Serial.println(response.getJSONBody());
-    }
-  }
-  saveKeys();
-  return installationId;
+    snprintf(buff, sizeof(buff),
+             "%1x%1x%1x%1x%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x",
+             rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16,
+             rand() % 16, rand() % 16, rand() % 16, rand() % 16,
+             rand() % 16, rand() % 16, rand() % 16, rand() % 16,
+             rand() % 16, rand() % 16, rand() % 16, rand() % 16,
+             rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16);
+    return String(buff);
 }
 
-void ParseClient::setSessionToken(const char *sessionToken) {
-  if ((sessionToken != NULL) && (strlen(sessionToken) > 0 )) {
-    if (strcmp(this->sessionToken, sessionToken))
-      dataIsDirty = true;
-    strncpy(this->sessionToken, sessionToken, sizeof(this->sessionToken));
-    if (Serial && DEBUG) {
-      Serial.print("setting the session for installation:");
-      Serial.println(installationId);
-    }
-    getInstallationId();
-    ParseResponse response = sendRequest("GET", "/1/sessions/me", "", "");
-    String installation = response.getString("installationId");
-    if (!installation.length() && strlen(installationId)) {
-      sendRequest("PUT", "/1/sessions/me", "{}\r\n", "");
-    }
-  } else {
-    if (sessionToken[0])
-      dataIsDirty = true;
-   this->sessionToken[0] = 0;
-  }
-}
-
-void ParseClient::clearSessionToken() {
-  setSessionToken(NULL);
-}
-
-const char* ParseClient::getSessionToken() {
-  if (!strlen(sessionToken))
-    return NULL;
-  return sessionToken;
-}
-
-ParseResponse ParseClient::sendRequest(const char* httpVerb, const char* httpPath, const char* requestBody, const char* urlParams) {
-  return sendRequest(String(httpVerb), String(httpPath), String(requestBody), String(urlParams));
-}
-
-ParseResponse ParseClient::sendRequest(const String& httpVerb, const String& httpPath, const String& requestBody, const String& urlParams) {
-  char buff[91] = {0};
-  //client.stop();
-
-  saveKeys();
-
-  if (Serial && DEBUG) {
-    Serial.print("sendRequest(\"");
-    Serial.print(httpVerb.c_str());
-    Serial.print("\", \"");
-    Serial.print(httpPath.c_str());
-    Serial.print("\", \"");
-    Serial.print(requestBody.c_str());
-    Serial.print("\", \"");
-    Serial.print(urlParams.c_str());
-    Serial.println("\")");
-  }
-
-  int retry = 3;
-  bool connected;
-  
-  client.setFingerprint(hostFingerprint);
-
-  while(!(connected = client.connect(serverURL, SSL_PORT)) && retry--) {
-    Serial.printf("connecting...%d\n", retry);
-    yield();
-  }
-
-  if (connected) {
-    if (Serial && DEBUG) {
-      Serial.println("connected to server");
-      Serial.println(applicationId);
-      Serial.println(clientKey);
-      Serial.println(installationId);
-    }
-    if (urlParams.length() > 0) {
-        snprintf(buff, sizeof(buff) - 1, "%s %s?%s HTTP/1.1\r\n", httpVerb.c_str(), httpPath.c_str(), urlParams.c_str());
-    } else {
-        snprintf(buff, sizeof(buff) - 1, "%s %s HTTP/1.1\r\n", httpVerb.c_str(), httpPath.c_str());
-    }
-    sendAndEchoToSerial(client, buff);
-    snprintf(buff, sizeof(buff) - 1, "Host: %s\r\n",  serverURL);
-    sendAndEchoToSerial(client, buff);
-    snprintf(buff, sizeof(buff) - 1, "X-Parse-Client-Version: %s\r\n", CLIENT_VERSION);
-    sendAndEchoToSerial(client, buff);
-    snprintf(buff, sizeof(buff) - 1, "X-Parse-Application-Id: %s\r\n", applicationId);
-    sendAndEchoToSerial(client, buff);
-    snprintf(buff, sizeof(buff) - 1, "X-Parse-Client-Key: %s\r\n", clientKey);
-    sendAndEchoToSerial(client, buff);
-
-    if (strlen(installationId) > 0) {
-      snprintf(buff, sizeof(buff) - 1, "X-Parse-Installation-Id: %s\r\n", installationId);
-      sendAndEchoToSerial(client, buff);
-    }
-    if (strlen(sessionToken) > 0) {
-      snprintf(buff, sizeof(buff) - 1, "X-Parse-Session-Token: %s\r\n", sessionToken);
-      sendAndEchoToSerial(client, buff);
-    }
-    if (requestBody.length() > 0 && httpVerb != "GET") {
-      requestBody;
-      sendAndEchoToSerial(client, "Content-Type: application/json; charset=utf-8\r\n");
-    } else if (urlParams.length() > 0) {
-      sendAndEchoToSerial(client, "Content-Type: html/text\r\n");
-    }
-    if (requestBody.length() > 0 && httpVerb != "GET") {
-      snprintf(buff, sizeof(buff) - 1, "Content-Length: %d\r\n", requestBody.length());
-      sendAndEchoToSerial(client, buff);
-    }
-    sendAndEchoToSerial(client, "Connection: close\r\n");
-    sendAndEchoToSerial(client, "\r\n");
-    if (requestBody.length() > 0) {
-      sendAndEchoToSerial(client, requestBody.c_str());
-    }
-  } else {
+static void sendAndEchoToSerial(WiFiClientSecure &client, const char *line)
+{
+    client.print(line);
     if (Serial && DEBUG)
-      Serial.println("failed to connect to server");
-  }
-  ParseResponse response(&client);
-  return response;
+        Serial.print(line);
 }
 
-bool ParseClient::startPushService() {
+ParseClient::ParseClient()
+{
+    memset(applicationId, 0, sizeof(applicationId));
+    memset(clientKey, 0, sizeof(clientKey));
+    memset(serverURL, 0, sizeof(serverURL));
+    memset(hostFingerprint, 0, sizeof(hostFingerprint));
+    memset(installationId, 0, sizeof(installationId));
+    memset(sessionToken, 0, sizeof(sessionToken));
+    memset(lastPushTime, 0, sizeof(lastPushTime));
+    lastHeartbeat = 0;
+    dataIsDirty = false;
+}
+
+ParseClient::~ParseClient()
+{
+    end();
+}
+
+void ParseClient::begin(const char *applicationId, const char *clientKey)
+{
+    if (Serial && DEBUG)
+    {
+        Serial.print("begin(");
+        Serial.print(applicationId ? applicationId : "NULL");
+        Serial.print(", ");
+        Serial.print(clientKey ? clientKey : "NULL");
+        Serial.println(")");
+    }
+
+    if (applicationId)
+    {
+        strncpy(this->applicationId, applicationId, sizeof(this->applicationId));
+    }
+    if (clientKey)
+    {
+        strncpy(this->clientKey, clientKey, sizeof(this->clientKey));
+    }
+    restoreKeys();
+}
+
+void ParseClient::setServerURL(const char *serverURL)
+{
+    Serial.print("setting serverURL(");
+    Serial.print(serverURL ? serverURL : "NULL");
+    Serial.println(")");
+    if (serverURL)
+    {
+        strncpy(this->serverURL, serverURL, sizeof(this->serverURL));
+    }
+}
+
+void ParseClient::setHostFingerprint(const char *hostFingerprint)
+{
+    Serial.print("setting hostFingerprint(");
+    Serial.print(hostFingerprint ? hostFingerprint : "NULL");
+    Serial.println(")");
+    if (hostFingerprint)
+    {
+        strncpy(this->hostFingerprint, hostFingerprint, sizeof(this->hostFingerprint));
+    }
+}
+
+void ParseClient::setClientInsecure()
+{
+    Serial.println("setting connection client insecure");
+    client.setInsecure();
+}
+
+void ParseClient::setInstallationId(const char *installationId)
+{
+    if (installationId)
+    {
+        if (strcmp(this->installationId, installationId))
+            dataIsDirty = true;
+        strncpy(this->installationId, installationId, sizeof(this->installationId));
+    }
+    else
+    {
+        if (this->installationId[0])
+            dataIsDirty = true;
+        strncpy(this->installationId, "", sizeof(this->installationId));
+    }
+}
+
+const char *ParseClient::getInstallationId()
+{
+    if (!strlen(installationId))
+    {
+        setInstallationId(createNewInstallationId().c_str());
+        // char buff[40];
+
+        if (Serial && DEBUG)
+        {
+            Serial.print("creating new installationId:");
+            Serial.println(installationId);
+        }
+
+        char content[120];
+        snprintf(content, sizeof(content), "{\"installationId\": \"%s\", \"deviceType\": \"embedded\", \"parseVersion\": \"1.0.0\"}", installationId);
+
+        ParseResponse response = sendRequest("POST", "/1/installations", content, "");
+        if (Serial && DEBUG)
+        {
+            Serial.print("response:");
+            Serial.println(response.getJSONBody());
+        }
+    }
+    saveKeys();
+    return installationId;
+}
+
+void ParseClient::setSessionToken(const char *sessionToken)
+{
+    if ((sessionToken != NULL) && (strlen(sessionToken) > 0))
+    {
+        if (strcmp(this->sessionToken, sessionToken))
+            dataIsDirty = true;
+        strncpy(this->sessionToken, sessionToken, sizeof(this->sessionToken));
+        if (Serial && DEBUG)
+        {
+            Serial.print("setting the session for installation:");
+            Serial.println(installationId);
+        }
+        getInstallationId();
+        ParseResponse response = sendRequest("GET", "/1/sessions/me", "", "");
+        String installation = response.getString("installationId");
+        if (!installation.length() && strlen(installationId))
+        {
+            sendRequest("PUT", "/1/sessions/me", "{}\r\n", "");
+        }
+    }
+    else
+    {
+        if (sessionToken[0])
+            dataIsDirty = true;
+        this->sessionToken[0] = 0;
+    }
+}
+
+void ParseClient::clearSessionToken()
+{
+    setSessionToken(NULL);
+}
+
+const char *ParseClient::getSessionToken()
+{
+    if (!strlen(sessionToken))
+        return NULL;
+    return sessionToken;
+}
+
+ParseResponse ParseClient::sendRequest(const char *httpVerb, const char *httpPath, const char *requestBody, const char *urlParams)
+{
+    return sendRequest(String(httpVerb), String(httpPath), String(requestBody), String(urlParams));
+}
+
+ParseResponse ParseClient::sendRequest(const String &httpVerb, const String &httpPath, const String &requestBody, const String &urlParams)
+{
+    char buff[91] = {0};
+    //client.stop();
+
+    saveKeys();
+
+    if (Serial && DEBUG)
+    {
+        Serial.print("sendRequest(\"");
+        Serial.print(httpVerb.c_str());
+        Serial.print("\", \"");
+        Serial.print(httpPath.c_str());
+        Serial.print("\", \"");
+        Serial.print(requestBody.c_str());
+        Serial.print("\", \"");
+        Serial.print(urlParams.c_str());
+        Serial.println("\")");
+    }
+
+    int retry = 3;
+    bool connected;
+
+    client.setFingerprint(hostFingerprint);
+
+    while (!(connected = client.connect(serverURL, SSL_PORT)) && retry--)
+    {
+        Serial.printf("connecting...%d\n", retry);
+        yield();
+    }
+
+    if (connected)
+    {
+        if (Serial && DEBUG)
+        {
+            Serial.println("connected to server");
+            Serial.println(applicationId);
+            Serial.println(clientKey);
+            Serial.println(installationId);
+        }
+        if (urlParams.length() > 0)
+        {
+            snprintf(buff, sizeof(buff) - 1, "%s %s?%s HTTP/1.1\r\n", httpVerb.c_str(), httpPath.c_str(), urlParams.c_str());
+        }
+        else
+        {
+            snprintf(buff, sizeof(buff) - 1, "%s %s HTTP/1.1\r\n", httpVerb.c_str(), httpPath.c_str());
+        }
+        sendAndEchoToSerial(client, buff);
+        snprintf(buff, sizeof(buff) - 1, "Host: %s\r\n", serverURL);
+        sendAndEchoToSerial(client, buff);
+        snprintf(buff, sizeof(buff) - 1, "X-Parse-Client-Version: %s\r\n", CLIENT_VERSION);
+        sendAndEchoToSerial(client, buff);
+        snprintf(buff, sizeof(buff) - 1, "X-Parse-Application-Id: %s\r\n", applicationId);
+        sendAndEchoToSerial(client, buff);
+        snprintf(buff, sizeof(buff) - 1, "X-Parse-Client-Key: %s\r\n", clientKey);
+        sendAndEchoToSerial(client, buff);
+
+        if (strlen(installationId) > 0)
+        {
+            snprintf(buff, sizeof(buff) - 1, "X-Parse-Installation-Id: %s\r\n", installationId);
+            sendAndEchoToSerial(client, buff);
+        }
+        if (strlen(sessionToken) > 0)
+        {
+            snprintf(buff, sizeof(buff) - 1, "X-Parse-Session-Token: %s\r\n", sessionToken);
+            sendAndEchoToSerial(client, buff);
+        }
+        if (requestBody.length() > 0 && httpVerb != "GET")
+        {
+            // requestBody;
+            sendAndEchoToSerial(client, "Content-Type: application/json; charset=utf-8\r\n");
+        }
+        else if (urlParams.length() > 0)
+        {
+            sendAndEchoToSerial(client, "Content-Type: html/text\r\n");
+        }
+        if (requestBody.length() > 0 && httpVerb != "GET")
+        {
+            snprintf(buff, sizeof(buff) - 1, "Content-Length: %d\r\n", requestBody.length());
+            sendAndEchoToSerial(client, buff);
+        }
+        sendAndEchoToSerial(client, "Connection: close\r\n");
+        sendAndEchoToSerial(client, "\r\n");
+        if (requestBody.length() > 0)
+        {
+            sendAndEchoToSerial(client, requestBody.c_str());
+        }
+    }
+    else
+    {
+        if (Serial && DEBUG)
+            Serial.println("failed to connect to server");
+    }
+    ParseResponse response(&client);
+    return response;
+}
+
+bool ParseClient::startPushService()
+{
     pushClient.stop();
 
     saveKeys();
@@ -296,126 +345,159 @@ bool ParseClient::startPushService() {
         Serial.println("start push");
 
     int retry = 3;
-    bool connected;
+    bool connected = false;
 
-    while(!(connected = pushClient.connect(PARSE_PUSH, SSL_PORT)) && retry--);
+    while (!(connected = pushClient.connect(PARSE_PUSH, SSL_PORT)) && retry--)
+        ;
 
-    if (connected) {
+    if (connected)
+    {
         if (Serial && DEBUG)
             Serial.println("push started");
-            char buff[256] = {0};
-            snprintf(buff, sizeof(buff),
-                "{\"installation_id\":\"%s\", \"oauth_key\":\"%s\", "
-                "\"v\":\"e1.0.0\", \"last\":%s%s%s}\r\n{}\r\n",
-                installationId,
-                applicationId,
-                lastPushTime[0] ? "\"" : "",
-                lastPushTime[0] ? lastPushTime : "null",
-                lastPushTime[0] ? "\"" : "");
-            sendAndEchoToSerial(pushClient, buff);
-        } else {
+        char buff[256] = {0};
+        snprintf(buff, sizeof(buff),
+                 "{\"installation_id\":\"%s\", \"oauth_key\":\"%s\", "
+                 "\"v\":\"e1.0.0\", \"last\":%s%s%s}\r\n{}\r\n",
+                 installationId,
+                 applicationId,
+                 lastPushTime[0] ? "\"" : "",
+                 lastPushTime[0] ? lastPushTime : "null",
+                 lastPushTime[0] ? "\"" : "");
+        sendAndEchoToSerial(pushClient, buff);
+    }
+    else
+    {
         if (Serial && DEBUG)
             Serial.println("failed to connect to push server");
     }
+    return connected;
 }
 
-ParsePush ParseClient::nextPush() {
-  ParsePush push(&pushClient);
-  if (pushBuff[0]) {
-    push.setLookahead(pushBuff);
-    memset(pushBuff, 0, sizeof(pushBuff));
-  }
-  return push;
-}
-
-bool ParseClient::pushAvailable() {
-  bool available = (pushClient.available() > 0);
-  // send keepalive if connected.
-  if (!available && pushClient.connected() && millis() - lastHeartbeat > 1000 * 60 * 12) {
-    pushClient.println("{}");
-    lastHeartbeat = millis();
-  }
-  if (pushBuff[0]) {
-    available = true;
-  } else {
-    for (int i = 0; i < sizeof(pushBuff) && (pushClient.available() > 0); ++i) {
-      pushBuff[i] = pushClient.read();
-    }
-    if (!strncmp(pushBuff, "{}", 2)) {
-      int i = 2;
-      for (; pushBuff[i] == '\r' || pushBuff[i] == '\n'; ++i);
-      if (pushBuff[i]) {
-        int j = i;;
-        for (; pushBuff[i]; ++i)
-          pushBuff[i - j] = pushBuff[i];
-        pushBuff[i - j] = 0;
-      } else {
+ParsePush ParseClient::nextPush()
+{
+    ParsePush push(&pushClient);
+    if (pushBuff[0])
+    {
+        push.setLookahead(pushBuff);
         memset(pushBuff, 0, sizeof(pushBuff));
-        available = (pushClient.available() > 0);
-      }
     }
-  }
-  return available;
+    return push;
 }
 
-void ParseClient::stopPushService() {
-  pushClient.stop();
+bool ParseClient::pushAvailable()
+{
+    bool available = (pushClient.available() > 0);
+    // send keepalive if connected.
+    if (!available && pushClient.connected() && millis() - lastHeartbeat > 1000 * 60 * 12)
+    {
+        pushClient.println("{}");
+        lastHeartbeat = millis();
+    }
+    if (pushBuff[0])
+    {
+        available = true;
+    }
+    else
+    {
+        for (unsigned long i = 0; i < sizeof(pushBuff) && (pushClient.available() > 0); ++i)
+        {
+            pushBuff[i] = pushClient.read();
+        }
+        if (!strncmp(pushBuff, "{}", 2))
+        {
+            int i = 2;
+            for (; pushBuff[i] == '\r' || pushBuff[i] == '\n'; ++i)
+                ;
+            if (pushBuff[i])
+            {
+                int j = i;
+                ;
+                for (; pushBuff[i]; ++i)
+                    pushBuff[i - j] = pushBuff[i];
+                pushBuff[i - j] = 0;
+            }
+            else
+            {
+                memset(pushBuff, 0, sizeof(pushBuff));
+                available = (pushClient.available() > 0);
+            }
+        }
+    }
+    return available;
 }
 
-void ParseClient::end() {
-  stopPushService();
+void ParseClient::stopPushService()
+{
+    pushClient.stop();
 }
 
-void ParseClient::saveKeys() {
+void ParseClient::end()
+{
+    stopPushService();
+}
+
+void ParseClient::saveKeys()
+{
 #if 0
-  if (dataIsDirty) {
+    if (dataIsDirty)
+    {
+        KeysInternalStorage stored_keys = parse_flash_store.read();
+
+        stored_keys.assigned = true;
+        strcpy(stored_keys.installationId, installationId);
+        strcpy(stored_keys.sessionToken, sessionToken);
+        strcpy(stored_keys.lastPushTime, lastPushTime);
+        parse_flash_store.write(stored_keys);
+        if (Serial && DEBUG)
+        {
+            Serial.println("ParseClient::saveKeys() : done.");
+        }
+        dataIsDirty = false;
+    }
+    else
+    {
+        if (Serial && DEBUG)
+        {
+            Serial.println("ParseClient::saveKeys() : keys are not changed - skipping...");
+        }
+    }
+#endif
+}
+
+void ParseClient::restoreKeys()
+{
+#if 0
     KeysInternalStorage stored_keys = parse_flash_store.read();
 
-    stored_keys.assigned = true;
-    strcpy(stored_keys.installationId, installationId);
-    strcpy(stored_keys.sessionToken, sessionToken);
-    strcpy(stored_keys.lastPushTime, lastPushTime);
-    parse_flash_store.write(stored_keys);
-    if (Serial && DEBUG) {
-      Serial.println("ParseClient::saveKeys() : done.");
+    if (stored_keys.assigned)
+    {
+        strcpy(installationId, stored_keys.installationId);
+        strcpy(sessionToken, stored_keys.sessionToken);
+        strcpy(lastPushTime, stored_keys.lastPushTime);
+        if (Serial && DEBUG)
+        {
+            Serial.println("ParseClient::restoreKeys() : done:");
+            Serial.println(installationId);
+            Serial.println(sessionToken);
+            Serial.println(lastPushTime);
+        }
     }
-    dataIsDirty = false;
-  } else {
-    if (Serial && DEBUG) {
-      Serial.println("ParseClient::saveKeys() : keys are not changed - skipping...");
+    else
+    {
+        if (Serial && DEBUG)
+        {
+            Serial.println("ParseClient::restoreKeys() : nothing is stored.");
+        }
     }
-  }
 #endif
 }
 
-void ParseClient::restoreKeys() {
-#if 0
-  KeysInternalStorage stored_keys = parse_flash_store.read();
-
-  if (stored_keys.assigned) {
-    strcpy(installationId, stored_keys.installationId);
-    strcpy(sessionToken, stored_keys.sessionToken);
-    strcpy(lastPushTime, stored_keys.lastPushTime);
-    if (Serial && DEBUG) {
-      Serial.println("ParseClient::restoreKeys() : done:");
-      Serial.println(installationId);
-      Serial.println(sessionToken);
-      Serial.println(lastPushTime);
-    }
-  } else {
-    if (Serial && DEBUG) {
-      Serial.println("ParseClient::restoreKeys() : nothing is stored.");
-    }
-  }
-#endif
+void ParseClient::saveLastPushTime(char *time)
+{
+    dataIsDirty = true;
+    strcpy(lastPushTime, time);
+    saveKeys();
 }
-
-void ParseClient::saveLastPushTime(char *time) {
-  dataIsDirty = true;
-  strcpy(lastPushTime, time);
-  saveKeys();
-}
-
 
 ParseClient Parse;
 

--- a/src/internal/esp8266/ParsePush.cpp
+++ b/src/internal/esp8266/ParsePush.cpp
@@ -19,35 +19,42 @@
  *
  */
 
-#if defined (ARDUINO_ARCH_ESP8266)
+#if defined(ARDUINO_ARCH_ESP8266)
 
 #include "../ParsePush.h"
 #include "../ParseClient.h"
 #include "../ParseUtils.h"
 
-ParsePush::ParsePush(WiFiClientSecure* pushClient) : ParseResponse(pushClient) {
+ParsePush::ParsePush(WiFiClientSecure *pushClient) : ParseResponse(pushClient)
+{
     memset(lookahead, 0, sizeof(lookahead));
 }
 
-void ParsePush::close() {
+void ParsePush::close()
+{
     freeBuffer();
 }
 
-void ParsePush::setLookahead(const char *read_data) {
+void ParsePush::setLookahead(const char *read_data)
+{
     strncpy(lookahead, read_data, sizeof(lookahead));
 }
 
-void ParsePush::read() {
-    if (buf == NULL) {
+void ParsePush::read()
+{
+    if (buf == NULL)
+    {
         bufSize = BUFSIZE;
         buf = new char[bufSize];
     }
 
-    if (p == bufSize - 1) {
+    if (p == bufSize - 1)
+    {
         return;
     }
 
-    if (p == 0) {
+    if (p == 0)
+    {
         memset(buf, 0, bufSize);
         for (; lookahead[p]; ++p)
             buf[p] = lookahead[p];
@@ -55,23 +62,28 @@ void ParsePush::read() {
     }
 
     char c;
-    while (client->connected()) {
-        if (client->available()) {
+    while (client->connected())
+    {
+        if (client->available())
+        {
             c = client->read();
-            if (c == '\n') c = '\0';
-            if (p < bufSize - 1) {
+            if (c == '\n')
+                c = '\0';
+            if (p < bufSize - 1)
+            {
                 *(buf + p) = c;
                 p++;
             }
-            if (c == '\0') break;
+            if (c == '\0')
+                break;
         }
     }
     p = 0;
     char time[41];
-    if (ParseUtils::getStringFromJSON(buf, "time", time, sizeof(time))) {
-      Parse.saveLastPushTime(time);
+    if (ParseUtils::getStringFromJSON(buf, "time", time, sizeof(time)))
+    {
+        Parse.saveLastPushTime(time);
     }
 }
 
 #endif // ARDUINO_ARCH_ESP8266
-

--- a/src/internal/esp8266/ParseResponse.cpp
+++ b/src/internal/esp8266/ParseResponse.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-#if defined (ARDUINO_ARCH_ESP8266)
+#if defined(ARDUINO_ARCH_ESP8266)
 
 #include "../ParseResponse.h"
 #include "../ParseInternal.h"
@@ -36,412 +36,482 @@ static const int kBufferSize = 1024;
 // Uncomment following line if you want to debug query response with serial output.
 // #define DEBUG_RESPONSE
 
-ParseResponse::ParseResponse(ConnectionClient* client) {
-  buf = NULL;
-  tmpBuf = NULL;
-  p = 0;
-  resultCount = -1;
-  bufSize = 0;
-  isUserBuffer = false;
-  isChunked = false;
-  responseLength = 0;
-  dataDone = false;
-  this->client = client;
-  bufferPos = kBufferSize;
-  lastRead = -1;
+ParseResponse::ParseResponse(ConnectionClient *client)
+{
+    buf = NULL;
+    tmpBuf = NULL;
+    p = 0;
+    resultCount = -1;
+    bufSize = 0;
+    isUserBuffer = false;
+    isChunked = false;
+    responseLength = 0;
+    dataDone = false;
+    this->client = client;
+    bufferPos = kBufferSize;
+    lastRead = -1;
 }
 
-ParseResponse::~ParseResponse() {
-  close();
+ParseResponse::~ParseResponse()
+{
+    close();
 }
 
-void ParseResponse::setBuffer(char* buffer, int size) {
-  if (!buffer || size <= 0) {
-    return;
-  }
+void ParseResponse::setBuffer(char *buffer, int size)
+{
+    if (!buffer || size <= 0)
+    {
+        return;
+    }
 
-  buf = buffer;
-  bufSize = size;
-  isUserBuffer = true;
-  memset(buf, 0, bufSize);
-}
-
-int ParseResponse::available() {
-  return client->available();
-}
-
-void ParseResponse::read() {
-  if (dataDone)
-    return;
-  if (buf == NULL) {
-    bufSize = BUFSIZE;
-    buf = new char[bufSize];
+    buf = buffer;
+    bufSize = size;
+    isUserBuffer = true;
     memset(buf, 0, bufSize);
-  }
+}
 
-  if (p == bufSize - 1) {
-    return;
-  }
+int ParseResponse::available()
+{
+    return client->available();
+}
 
-  memset(buf + p, 0, bufSize - p);
+void ParseResponse::read()
+{
+    if (dataDone)
+        return;
+    if (buf == NULL)
+    {
+        bufSize = BUFSIZE;
+        buf = new char[bufSize];
+        memset(buf, 0, bufSize);
+    }
 
-  char c;
-  int i;
+    if (p == bufSize - 1)
+    {
+        return;
+    }
 
-  bool data = false;
-  int count = 0;
+    memset(buf + p, 0, bufSize - p);
 
-  while (client->connected()) {
-    delay(1);
-    while (client->available()) {
-      c = client->read();
-      if (c != '\r') { // filter out '\r' character
-        if (data) {
-          if (p < bufSize - 1) {
-            *(buf + p) = c;
-            p++;
-          }
+    char c;
+    // int i;
+
+    bool data = false;
+    int count = 0;
+
+    while (client->connected())
+    {
+        delay(1);
+        while (client->available())
+        {
+            c = client->read();
+            if (c != '\r')
+            { // filter out '\r' character
+                if (data)
+                {
+                    if (p < bufSize - 1)
+                    {
+                        *(buf + p) = c;
+                        p++;
+                    }
+                }
+                // filter out the headers
+                if (c == '\n')
+                    count++;
+                else
+                    count = 0;
+                if (count >= 2)
+                    data = true;
+            }
         }
-        // filter out the headers
-        if (c == '\n') count++; else count = 0;
-        if (count >= 2) data = true;
-      }
     }
-  }
-  dataDone = 1;
+    dataDone = 1;
 }
 
-void ParseResponse::readLine(char *buff, int sz) {
-  memset(buff, 0, sz);
+void ParseResponse::readLine(char *buff, int sz)
+{
+    memset(buff, 0, sz);
 #ifdef DEBUG_RESPONSE
-  Serial.print("Read line:");
+    Serial.print("Read line:");
 #endif
-  for (int i = 0; client->available(); ++i) {
-    char c = client->read();
-    if (c == '\r') {
-      client->read(); // read /n
-      return;
-    }
-    if (c == '\n') {
-      return;
-    }
+    for (int i = 0; client->available(); ++i)
+    {
+        char c = client->read();
+        if (c == '\r')
+        {
+            client->read(); // read /n
+            return;
+        }
+        if (c == '\n')
+        {
+            return;
+        }
 #ifdef DEBUG_RESPONSE
-    Serial.print(c);
+        Serial.print(c);
 #endif
-    if (i < sz - 1)
-      buff[i] = c;
-  }
+        if (i < sz - 1)
+            buff[i] = c;
+    }
 #ifdef DEBUG_RESPONSE
-  Serial.println("");
+    Serial.println("");
 #endif
 }
 
-bool ParseResponse::readJson(char *buff, int sz) {
-  memset(buff, 0, sz);
+bool ParseResponse::readJson(char *buff, int sz)
+{
+    memset(buff, 0, sz);
 
-  int read_bytes = 0;
+    int read_bytes = 0;
 
-  bool res = readJsonInternal(buff, sz, &read_bytes, '\0');
-  if (!res) {
+    bool res = readJsonInternal(buff, sz, &read_bytes, '\0');
+    if (!res)
+    {
 #ifdef DEBUG_RESPONSE
-    Serial.print("Failed");
+        Serial.print("Failed");
+        Serial.println(buff);
+#endif
+    }
+    return res;
+}
+
+bool ParseResponse::readJsonInternal(char *buff, int sz, int *read_bytes, char started)
+{
+    // It is our own JSON, so we can be *very* strict in regars to format.
+    char in_string = '\0';
+    int ch;
+    int i;
+
+    // char tmp[32];
+
+    for (i = 0;; ++i)
+    {
+        bool skip = false;
+        if ((ch = readChunkedData(kQueryTimeout)) < 0)
+        {
+            *read_bytes = i;
+            return false;
+        }
+        switch (ch)
+        {
+        case '\"':
+        case '\'':
+            if (in_string == ch)
+                in_string = '\0';
+            else if (in_string == '\0')
+                in_string = ch;
+            break;
+        case ',':
+            if (in_string)
+                break;
+            if (!started)
+            {
+                --i; // skip
+                skip = true;
+            }
+            break;
+        case '[':
+        case '{':
+        {
+            if (in_string)
+                break;
+            if (!started)
+            {
+                started = ch;
+                break;
+            }
+            int added = 0;
+            if (i < sz)
+                buff[i] = ch;
+            bool success = readJsonInternal(buff + i + 1, sz - i - 1, &added, ch);
+            if (!success)
+                return false;
+            i += added;
+            skip = true;
+        }
+        break;
+        case '}':
+        case ']':
+        {
+            if (in_string)
+                break;
+            if (!started)
+                return false;
+            if ((started == '[' && ch != ']') || (started == '{' && ch != '}'))
+                return false;
+            if (i < sz)
+                buff[i] = ch;
+            *read_bytes = i + 1;
+            return true;
+        }
+        break;
+        }
+        if (!skip && i < sz - 1)
+            buff[i] = ch;
+    }
+}
+
+#ifdef DEBUG_RESPONSE
+void printData(char *d, int sz, int offset)
+{
+    char t1[32];
+    sprintf(t1, "\r\n%d %04x[->", sz, offset);
+    Serial.print(t1);
+    char tmp[4] = {0};
+    for (int i = 0; i < sz; ++i)
+    {
+        if (d[i] >= 32 && d[i] <= 127)
+            tmp[0] = d[i];
+        else
+            tmp[0] = '?';
+        Serial.print(tmp);
+    }
+    Serial.println("<-]");
+}
+#endif
+
+int ParseResponse::readChunkedData(int timeout)
+{
+
+    char snum[16];
+
+    if (bufferPos == kBufferSize || (lastRead > 0 && bufferPos == lastRead))
+    {
+        for (int i = 0; i < timeout && !client->available(); ++i)
+        {
+            delay(1);
+        }
+
+        if (responseLength <= 0)
+        {
+            readLine(snum, sizeof(snum));
+            readLine(snum, sizeof(snum));
+            char *tmp;
+#ifdef DEBUG_RESPONSE
+            Serial.println("");
+            Serial.print("Next chunk:");
+            Serial.println(snum);
+#endif
+            responseLength = strtol(snum, &tmp, 16);
+            if (!responseLength)
+                return -1;
+        }
+        if (client->available())
+        {
+            int to_read = responseLength > kBufferSize ? kBufferSize : responseLength;
+            bufferPos = 0;
+            int sz = client->read((uint8_t *)chunkedBuffer, to_read);
+            lastRead = sz;
+#ifdef DEBUG_RESPONSE
+            Serial.println();
+            Serial.print("Read: ");
+            Serial.println(sz);
+            Serial.println();
+            Serial.print("bufferPos: ");
+            Serial.println(bufferPos);
+            Serial.println();
+            Serial.print("to_read: ");
+            Serial.println(to_read);
+            Serial.println();
+            Serial.print("responseLength: ");
+            Serial.println(responseLength);
+            printData(chunkedBuffer, sz, bufferPos);
+#endif
+            if (sz <= 0)
+                return -1;
+            responseLength -= sz;
+        }
+    }
+    int ch = chunkedBuffer[bufferPos++];
+    return ch;
+}
+
+int ParseResponse::getErrorCode()
+{
+    return getInt("code");
+}
+
+const char *ParseResponse::getJSONBody()
+{
+    read();
+    return buf;
+}
+
+const char *ParseResponse::getString(const char *key)
+{
+    read();
+    if (!tmpBuf)
+    {
+        tmpBuf = new char[64];
+    }
+    memset(tmpBuf, 0, 64);
+    ParseUtils::getStringFromJSON(buf, key, tmpBuf, 64);
+    return tmpBuf;
+}
+
+int ParseResponse::getInt(const char *key)
+{
+    read();
+    return ParseUtils::getIntFromJSON(buf, key);
+}
+
+double ParseResponse::getDouble(const char *key)
+{
+    read();
+    return ParseUtils::getFloatFromJSON(buf, key);
+}
+
+bool ParseResponse::getBoolean(const char *key)
+{
+    read();
+    return ParseUtils::getBooleanFromJSON(buf, key);
+}
+
+void ParseResponse::readWithTimeout(int maxSec)
+{
+    while ((!available()) && (maxSec--))
+    { // wait till response
+        delay(1000);
+    }
+    read();
+}
+
+bool ParseResponse::nextObject()
+{
+    if (resultCount <= 0)
+    {
+        count();
+    }
+
+    if (resultCount <= 0)
+    {
+        return false;
+    }
+
+    if (firstObject)
+    {
+        firstObject = false;
+        return true;
+    }
+    else
+    {
+        return readJson(buf, bufSize);
+    }
+}
+
+int ParseResponse::count()
+{
+    if (resultCount != -1)
+        return resultCount;
+    char buff[128];
+
+    resultCount = 0;
+
+    bool first_line = true;
+    bool __attribute__((unused)) ok = false;
+    bool done = false;
+    char *ptr;
+    // long len = 0;
+    while (client->connected() && !done)
+    {
+        delay(1);
+        while (client->available())
+        {
+            readLine(buff, sizeof(buff));
+            if (first_line)
+            {
+                if (!strcmp(kHttpOK, buff))
+                    ok = true;
+                first_line = false;
+            }
+#ifdef DEBUG_RESPONSE
+            Serial.print("H->");
+            Serial.println(buff);
+#endif
+            if (!strcmp(kChunkedEncoding, buff))
+            {
+                isChunked = true;
+            }
+            else if (!strncmp(kContentLength, buff, sizeof(kContentLength)))
+            {
+                responseLength = strtol(buff + sizeof(kContentLength), &ptr, 10);
+            }
+            else if (!buff[0])
+            {
+                if (isChunked && client->available())
+                {
+                    readLine(buff, sizeof(buff));
+                    responseLength = strtol(buff, &ptr, 16);
+#ifdef DEBUG_RESPONSE
+                    Serial.print("First chunk->");
+                    Serial.println(buff);
+#endif
+                }
+                done = true;
+                break;
+            }
+        }
+    }
+    long persistentResponseLength = responseLength; // responseLength is modified by calls to readChunkedData
+#ifdef DEBUG_RESPONSE
+    sprintf(buff, "Ok:%s Length:%d Chunked:%s", ok ? "y" : "n", responseLength, isChunked ? "y" : "n");
     Serial.println(buff);
 #endif
-  }
-  return res;
-}
+    done = false;
+    freeBuffer();
+    setBuffer(new char[kJsonResponseMaxSize], kJsonResponseMaxSize);
+    dataDone = true;
 
-bool ParseResponse::readJsonInternal(char *buff, int sz, int* read_bytes, char started) {
-  // It is our own JSON, so we can be *very* strict in regars to format.
-  char in_string = '\0';
-  int ch;
-  int i;
-
-  char tmp[32];
-
-  for (i = 0; ; ++i) {
-    bool skip = false;
-    if ((ch = readChunkedData(kQueryTimeout)) < 0) {
-      *read_bytes = i;
-      return false;
-    }
-    switch (ch) {
-      case '\"':
-      case '\'':
-        if (in_string == ch)
-          in_string = '\0';
-        else if (in_string == '\0')
-          in_string = ch;
-        break;
-      case ',':
-        if (in_string)
-          break;
-        if (!started) {
-          --i; // skip
-          skip = true;
+    for (unsigned long i = 0; i < sizeof(kResultsStart) - (unsigned long)1; ++i)
+    {
+        char c = readChunkedData(kQueryTimeout);
+        if (c != kResultsStart[i])
+        {
+#ifdef DEBUG_RESPONSE
+            Serial.println("Malformed response!");
+#endif
+            resultCount = -1;
+            return -1;
         }
-        break;
-      case '[':
-      case '{':
-      {
-        if (in_string)
-          break;
-        if (!started) {
-          started = ch;
-          break;
-        }
-        int added = 0;
-        if (i < sz)
-          buff[i] = ch;
-        bool success = readJsonInternal(buff + i + 1, sz - i - 1, &added, ch);
-        if (!success)
-          return false;
-        i += added;
-        skip = true;
-      } break;
-      case '}':
-      case ']':
-      {
-        if (in_string)
-          break;
-        if (!started)
-          return false;
-        if ((started == '[' && ch != ']') || (started == '{' && ch != '}'))
-          return false;
-        if (i < sz)
-          buff[i] = ch;
-        *read_bytes = i + 1;
-        return true;
-      } break;
     }
-    if (!skip && i < sz - 1)
-      buff[i] = ch;
-  }
-}
 
+    if (!readJson(buf, bufSize))
+    {
 #ifdef DEBUG_RESPONSE
-void printData(char *d, int sz, int offset) {
-  char t1[32];
-  sprintf(t1,"\r\n%d %04x[->", sz, offset);
-  Serial.print(t1);
-  char tmp[4] = {0};
-  for (int i = 0; i < sz; ++i) {
-    if (d[i] >= 32 && d[i] <= 127)
-      tmp[0] = d[i];
-    else
-      tmp[0] = '?';
-    Serial.print(tmp);
-  }
-  Serial.println("<-]");
-}
+        Serial.println("no results");
 #endif
-
-int ParseResponse::readChunkedData(int timeout) {
-
-  char snum[16];
-
-  if (bufferPos == kBufferSize || (lastRead > 0 && bufferPos == lastRead)) {
-    for (int i = 0; i < timeout && !client->available(); ++i) {
-        delay(1);
+        resultCount = 0;
+        return 0;
     }
 
-    if (responseLength <= 0) {
-      readLine(snum, sizeof(snum));
-      readLine(snum, sizeof(snum));
-      char *tmp;
-#ifdef DEBUG_RESPONSE
-      Serial.println("");
-      Serial.print("Next chunk:");
-      Serial.println(snum);
-#endif
-      responseLength = strtol(snum, &tmp, 16); 
-      if (!responseLength)
-        return -1;
-    }
-    if (client->available()) {
-      int to_read = responseLength > kBufferSize ? kBufferSize : responseLength;
-      bufferPos = 0;
-      int sz = client->read((uint8_t *)chunkedBuffer, to_read);
-      lastRead = sz;
-#ifdef DEBUG_RESPONSE
-      Serial.println();
-      Serial.print("Read: ");
-      Serial.println(sz);
-      Serial.println();
-      Serial.print("bufferPos: ");
-      Serial.println(bufferPos);
-      Serial.println();
-      Serial.print("to_read: ");
-      Serial.println(to_read);
-      Serial.println();
-      Serial.print("responseLength: ");
-      Serial.println(responseLength);
-      printData(chunkedBuffer, sz, bufferPos);
-#endif
-      if (sz <= 0)
-        return -1;
-      responseLength -= sz;
-    }
-  }
-  int ch = chunkedBuffer[bufferPos++];
-  return ch;
-}
+    int tmplen = strlen(buf);
+    firstObject = true;
+    if (tmplen > 0)
+        resultCount = persistentResponseLength / tmplen;
+    if (isChunked)
+        resultCount *= 2;
+    if (!resultCount)
+        resultCount = 1;
 
-int ParseResponse::getErrorCode() {
-  return getInt("code");
-}
-
-const char* ParseResponse::getJSONBody() {
-  read();
-  return buf;
-}
-
-const char* ParseResponse::getString(const char* key) {
-  read();
-  if (!tmpBuf) {
-    tmpBuf = new char[64];
-  }
-  memset(tmpBuf, 0, 64);
-  ParseUtils::getStringFromJSON(buf, key, tmpBuf, 64);
-  return tmpBuf;
-}
-
-int ParseResponse::getInt(const char* key) {
-  read();
-  return ParseUtils::getIntFromJSON(buf, key);
-}
-
-double ParseResponse::getDouble(const char* key) {
-  read();
-  return ParseUtils::getFloatFromJSON(buf, key);
-}
-
-bool ParseResponse::getBoolean(const char* key) {
-  read();
-  return ParseUtils::getBooleanFromJSON(buf, key);
-}
-
-void ParseResponse::readWithTimeout(int maxSec) {
-  while((!available()) && (maxSec--)) { // wait till response
-    delay(1000);
-  }
-  read();
-}
-
-bool ParseResponse::nextObject() {
-  if(resultCount <= 0) {
-    count();
-  }
-
-  if(resultCount <= 0) {
-    return false;
-  }
-
-  if (firstObject) {
-    firstObject = false;
-    return true;
-  } else {
-    return readJson(buf, bufSize);
-  }
-}
-
-int ParseResponse::count() {
-  if (resultCount != -1)
     return resultCount;
-  char buff[128];
-
-  resultCount = 0;
-
-  bool first_line = true;
-  bool ok = false;
-  bool done = false;
-  char *ptr;
-  long len = 0;
-  while (client->connected() && !done) {
-    delay(1);
-    while (client->available()) {
-      readLine(buff, sizeof(buff));
-      if (first_line) {
-        if (!strcmp(kHttpOK, buff))
-          ok = true;
-        first_line = false;
-      }
-#ifdef DEBUG_RESPONSE
-      Serial.print("H->");
-      Serial.println(buff);
-#endif
-      if (!strcmp(kChunkedEncoding, buff)) {
-        isChunked = true;
-      } else if (!strncmp(kContentLength, buff, sizeof(kContentLength))) {
-        responseLength = strtol(buff + sizeof(kContentLength), &ptr, 10);
-      } else if (!buff[0]) {
-        if (isChunked && client->available()) {
-          readLine(buff, sizeof(buff));
-          responseLength = strtol(buff, &ptr, 16);
-#ifdef DEBUG_RESPONSE
-          Serial.print("First chunk->");
-          Serial.println(buff);
-#endif
-        }
-        done = true;
-        break;
-      }
-    }
-  }
-  long persistentResponseLength = responseLength; // responseLength is modified by calls to readChunkedData
-#ifdef DEBUG_RESPONSE
-  sprintf(buff, "Ok:%s Length:%d Chunked:%s", ok ? "y" : "n", responseLength, isChunked ? "y" : "n");
-  Serial.println(buff);
-#endif
-  done = false;
-  freeBuffer();
-  setBuffer(new char[kJsonResponseMaxSize], kJsonResponseMaxSize);
-  dataDone = true;
-
-  for (int i = 0; i < sizeof(kResultsStart) - 1; ++i) {
-    char c = readChunkedData(kQueryTimeout);
-    if (c != kResultsStart[i]) {
-#ifdef DEBUG_RESPONSE
-      Serial.println("Malformed response!");
-#endif
-      resultCount = -1;
-      return -1;
-    }
-  }
-
-  if (!readJson(buf, bufSize)) {
-#ifdef DEBUG_RESPONSE
-    Serial.println("no results");
-#endif
-    resultCount = 0;
-    return 0;
-  }
-
-  int tmplen = strlen(buf);
-  firstObject = true;
-  if (tmplen > 0)
-    resultCount = persistentResponseLength / tmplen;
-  if (isChunked)
-    resultCount *= 2;
-  if (!resultCount)
-    resultCount = 1;
-
-  return resultCount;
 }
 
-void ParseResponse::freeBuffer() {
-  if (!isUserBuffer) { // only free non-user buffer
-    delete[] buf;
-    buf = NULL;
-  }
-  if (tmpBuf) {
-    delete[] tmpBuf;
-    tmpBuf = NULL;
-  }
+void ParseResponse::freeBuffer()
+{
+    if (!isUserBuffer)
+    { // only free non-user buffer
+        delete[] buf;
+        buf = NULL;
+    }
+    if (tmpBuf)
+    {
+        delete[] tmpBuf;
+        tmpBuf = NULL;
+    }
 }
 
-void ParseResponse::close() {
-  freeBuffer();
+void ParseResponse::close()
+{
+    freeBuffer();
 }
 
 #endif // ARDUINO_ARCH_ESP8266

--- a/src/internal/yun/ParseClient.cpp
+++ b/src/internal/yun/ParseClient.cpp
@@ -19,171 +19,211 @@
  *
  */
 
-
-#if defined (ARDUINO_AVR_YUN)
+#if defined(ARDUINO_AVR_YUN)
 
 #include "../ParseClient.h"
 #include "../ParseUtils.h"
 #include "../ParsePlatformSupport.h"
 
-ParseClient::ParseClient() {
-  applicationId[0] = '\0';
-  clientKey[0] = '\0';
-  installationId[0] = '\0';
-  sessionToken[0] = '\0';
-}
-
-ParseClient::~ParseClient() {
-  end();
-}
-
-void ParseClient::begin(const char *applicationId, const char *clientKey) {
-  Console.println("begin");
-
-  // send the info to linux through Bridge
-  if(applicationId) {
-    Bridge.put("appId", applicationId);
-  }
-  if (clientKey) {
-    Bridge.put("clientKey", clientKey);
-  }
-}
-
-void ParseClient::setServerURL(const char *serverURL) {
-  if (serverURL) {
-    Bridge.put("serverURL", serverURL);
-  }
-}
-
-void ParseClient::setInstallationId(const char *installationId) {
-  strncpy(this->installationId, installationId, sizeof(this->installationId));
-  if (installationId) {
-    Bridge.put("installationId", installationId);
-  } else {
-    Bridge.put("installationId", "");
-  }
-}
-
-const char* ParseClient::getInstallationId() {
-  if (this->installationId[0] == '\0') {
-    client.begin("parse_request");
-    client.addParameter("-i");
-    client.run();
-    ParsePlatformSupport::read(&client, this->installationId, sizeof(installationId));
-  }
-  return this->installationId;
-}
-
-void ParseClient::setSessionToken(const char *sessionToken) {
-  if ((sessionToken != NULL) && (sessionToken[0] != '\0')){
-    strncpy(this->sessionToken, sessionToken, sizeof(this->sessionToken));
-    Bridge.put("sessionToken", sessionToken);
-  } else {
-    Bridge.put("sessionToken", "");
-    this->sessionToken[0] = '\0';
-  }
-}
-
-void ParseClient::clearSessionToken() {
-  setSessionToken(NULL);
-}
-
-const char* ParseClient::getSessionToken() {
-  if (!this->sessionToken) {
-    char *buf = new char[33];
-
-    client.begin("parse_request");
-    client.addParameter("-s");
-    client.run();
-    ParsePlatformSupport::read(&client, buf, 33);
-    strncpy(this->sessionToken, buf, sizeof(this->sessionToken));
-  }
-  return this->sessionToken;
-}
-
-ParseResponse ParseClient::sendRequest(const char* httpVerb, const char* httpPath, const char* requestBody, const char* urlParams) {
-  return sendRequest(String(httpVerb), String(httpPath), String(requestBody), String(urlParams));
-}
-
-ParseResponse ParseClient::sendRequest(const String& httpVerb, const String& httpPath, const String& requestBody, const String& urlParams) {
-  while(client.available()) {
-    client.read();                // flush out the buffer in case there is any leftover data there
-  }
-  client.begin("parse_request");  // start a process that launch the "parse_request" command
-
-  if(ParseUtils::isSanitizedString(httpVerb)
-  && ParseUtils::isSanitizedString(httpPath)
-  && ParseUtils::isSanitizedString(requestBody)
-  && ParseUtils::isSanitizedString(urlParams)) {
-    client.addParameter("-v");
-    client.addParameter(httpVerb);
-    client.addParameter("-e");
-    client.addParameter(httpPath);
-    if (requestBody != "") {
-      client.addParameter("-d");
-      client.addParameter(requestBody);
-    }
-    if (urlParams != "") {
-      client.addParameter("-p");
-      client.addParameter(urlParams);
-      client.runAsynchronously();
-    } else {
-      client.run(); // Run the process and wait for its termination
-    }
-  }
-
-  ParseResponse response(&client);
-  return response;
-}
-
-bool ParseClient::startPushService() {
-  pushClient.begin("parse_push");  // start a process that launch the "parse_request" command
-  pushClient.runAsynchronously();
-
-  while(1) {
-    if(pushClient.available()) {
-      // read the push starting result
-      char c = pushClient.read();
-      while(pushClient.available()) {
-        pushClient.read();
-      }
-      if (c == 's') {
-        pushClient.write('n'); // send a signal that ready to consume next available push
-        return true;
-      } else {
-        return false;
-      }
-    }
-  }
-}
-
-ParsePush ParseClient::nextPush() {
-  ParsePush push(&pushClient);
-  return push;
-}
-
-bool ParseClient::pushAvailable() {
-  pushClient.write('n'); // send a signal that ready to consume next available push
-  if(pushClient.available()) {
-    return 1;
-  } else {
-    return 0;
-  }
-}
-
-void ParseClient::stopPushService() {
-  pushClient.close();
-}
-
-void ParseClient::end() {
-  if(installationId[0] != '\0') {
+ParseClient::ParseClient()
+{
+    applicationId[0] = '\0';
+    clientKey[0] = '\0';
     installationId[0] = '\0';
-  }
-  if(sessionToken[0] != '\0') {
     sessionToken[0] = '\0';
-  }
+}
 
-  stopPushService();
+ParseClient::~ParseClient()
+{
+    end();
+}
+
+void ParseClient::begin(const char *applicationId, const char *clientKey)
+{
+    Console.println("begin");
+
+    // send the info to linux through Bridge
+    if (applicationId)
+    {
+        Bridge.put("appId", applicationId);
+    }
+    if (clientKey)
+    {
+        Bridge.put("clientKey", clientKey);
+    }
+}
+
+void ParseClient::setServerURL(const char *serverURL)
+{
+    if (serverURL)
+    {
+        Bridge.put("serverURL", serverURL);
+    }
+}
+
+void ParseClient::setInstallationId(const char *installationId)
+{
+    strncpy(this->installationId, installationId, sizeof(this->installationId));
+    if (installationId)
+    {
+        Bridge.put("installationId", installationId);
+    }
+    else
+    {
+        Bridge.put("installationId", "");
+    }
+}
+
+const char *ParseClient::getInstallationId()
+{
+    if (this->installationId[0] == '\0')
+    {
+        client.begin("parse_request");
+        client.addParameter("-i");
+        client.run();
+        ParsePlatformSupport::read(&client, this->installationId, sizeof(installationId));
+    }
+    return this->installationId;
+}
+
+void ParseClient::setSessionToken(const char *sessionToken)
+{
+    if ((sessionToken != NULL) && (sessionToken[0] != '\0'))
+    {
+        strncpy(this->sessionToken, sessionToken, sizeof(this->sessionToken));
+        Bridge.put("sessionToken", sessionToken);
+    }
+    else
+    {
+        Bridge.put("sessionToken", "");
+        this->sessionToken[0] = '\0';
+    }
+}
+
+void ParseClient::clearSessionToken()
+{
+    setSessionToken(NULL);
+}
+
+const char *ParseClient::getSessionToken()
+{
+    if (!this->sessionToken)
+    {
+        char *buf = new char[33];
+
+        client.begin("parse_request");
+        client.addParameter("-s");
+        client.run();
+        ParsePlatformSupport::read(&client, buf, 33);
+        strncpy(this->sessionToken, buf, sizeof(this->sessionToken));
+    }
+    return this->sessionToken;
+}
+
+ParseResponse ParseClient::sendRequest(const char *httpVerb, const char *httpPath, const char *requestBody, const char *urlParams)
+{
+    return sendRequest(String(httpVerb), String(httpPath), String(requestBody), String(urlParams));
+}
+
+ParseResponse ParseClient::sendRequest(const String &httpVerb, const String &httpPath, const String &requestBody, const String &urlParams)
+{
+    while (client.available())
+    {
+        client.read(); // flush out the buffer in case there is any leftover data there
+    }
+    client.begin("parse_request"); // start a process that launch the "parse_request" command
+
+    if (ParseUtils::isSanitizedString(httpVerb) && ParseUtils::isSanitizedString(httpPath) && ParseUtils::isSanitizedString(requestBody) && ParseUtils::isSanitizedString(urlParams))
+    {
+        client.addParameter("-v");
+        client.addParameter(httpVerb);
+        client.addParameter("-e");
+        client.addParameter(httpPath);
+        if (requestBody != "")
+        {
+            client.addParameter("-d");
+            client.addParameter(requestBody);
+        }
+        if (urlParams != "")
+        {
+            client.addParameter("-p");
+            client.addParameter(urlParams);
+            client.runAsynchronously();
+        }
+        else
+        {
+            client.run(); // Run the process and wait for its termination
+        }
+    }
+
+    ParseResponse response(&client);
+    return response;
+}
+
+bool ParseClient::startPushService()
+{
+    pushClient.begin("parse_push"); // start a process that launch the "parse_request" command
+    pushClient.runAsynchronously();
+
+    while (1)
+    {
+        if (pushClient.available())
+        {
+            // read the push starting result
+            char c = pushClient.read();
+            while (pushClient.available())
+            {
+                pushClient.read();
+            }
+            if (c == 's')
+            {
+                pushClient.write('n'); // send a signal that ready to consume next available push
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}
+
+ParsePush ParseClient::nextPush()
+{
+    ParsePush push(&pushClient);
+    return push;
+}
+
+bool ParseClient::pushAvailable()
+{
+    pushClient.write('n'); // send a signal that ready to consume next available push
+    if (pushClient.available())
+    {
+        return 1;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+void ParseClient::stopPushService()
+{
+    pushClient.close();
+}
+
+void ParseClient::end()
+{
+    if (installationId[0] != '\0')
+    {
+        installationId[0] = '\0';
+    }
+    if (sessionToken[0] != '\0')
+    {
+        sessionToken[0] = '\0';
+    }
+
+    stopPushService();
 }
 
 ParseClient Parse;

--- a/src/internal/yun/ParsePlatformSupport.cpp
+++ b/src/internal/yun/ParsePlatformSupport.cpp
@@ -19,23 +19,27 @@
  *
  */
 
-
-#if defined (ARDUINO_AVR_YUN)
+#if defined(ARDUINO_AVR_YUN)
 
 #include "../ConnectionClient.h"
 #include "../ParsePlatformSupport.h"
 
-int ParsePlatformSupport::read(ConnectionClient* client, char* buf, int len) {
-  int p = 0;
-  while (p < (len-1) && client->available()) {
-    buf[p++] = client->read();
-  }
-  if (p > 0 && buf[p - 1] == '\n') {
-      buf[p - 1] = '\0';
-  } else {
-    buf[p] = '\0';
-  }
-  return p;
+int ParsePlatformSupport::read(ConnectionClient *client, char *buf, int len)
+{
+    int p = 0;
+    while (p < (len - 1) && client->available())
+    {
+        buf[p++] = client->read();
+    }
+    if (p > 0 && buf[p - 1] == '\n')
+    {
+        buf[p - 1] = '\0';
+    }
+    else
+    {
+        buf[p] = '\0';
+    }
+    return p;
 }
 
 #endif

--- a/src/internal/yun/ParsePush.cpp
+++ b/src/internal/yun/ParsePush.cpp
@@ -24,14 +24,16 @@
 #include "../ParseClient.h"
 #include "../ParsePush.h"
 
-ParsePush::ParsePush(Process* pushClient) : ParseResponse(pushClient) {
+ParsePush::ParsePush(Process *pushClient) : ParseResponse(pushClient)
+{
 }
 
-void ParsePush::close() {
-  // send signal to linux that the push is consumed.
-  // iterate into next push
-  client->write('n');
-  freeBuffer();
+void ParsePush::close()
+{
+    // send signal to linux that the push is consumed.
+    // iterate into next push
+    client->write('n');
+    freeBuffer();
 }
 
 #endif

--- a/src/internal/yun/ParseResponse.cpp
+++ b/src/internal/yun/ParseResponse.cpp
@@ -19,143 +19,171 @@
  *
  */
 
-#if defined (ARDUINO_AVR_YUN)
+#if defined(ARDUINO_AVR_YUN)
 
 #include "../ParseInternal.h"
 #include "../ParseClient.h"
 #include "../ParseResponse.h"
 #include "../ParsePlatformSupport.h"
 
-ParseResponse::ParseResponse(Process* client) {
-  p = 0;
-  buf = NULL;
-  tmpBuf = NULL;
-  bufSize = 0;
-  isUserBuffer = false;
-  this->client = client;
-}
-
-ParseResponse::~ParseResponse() {
-  close();
-}
-
-void ParseResponse::setBuffer(char* buffer, int size) {
-  if(!buffer || size <= 0) {
-    return;
-  }
-
-  buf = buffer;
-  bufSize = size;
-  isUserBuffer = true;
-  memset(buf, 0, bufSize);
-}
-
-int ParseResponse::available() {
-  return client->available();
-}
-
-void ParseResponse::read() {
-  if(buf == NULL) {
-    bufSize = BUFSIZE;
-    buf = new char[bufSize];
-  }
-  p += ParsePlatformSupport::read(client, buf + p, bufSize - p);
-}
-
-int ParseResponse::getErrorCode() {
-  return getInt("code");
-}
-
-const char* ParseResponse::getJSONBody() {
-  read();
-  return buf;
-}
-
-const char* ParseResponse::getString(const char* key) {
-  read();
-  if(!tmpBuf) {
-    tmpBuf = new char[64];
-  }
-  memset(tmpBuf, 0, 64);
-  ParseUtils::getStringFromJSON(buf, key, tmpBuf, 64);
-  return tmpBuf;
-}
-
-int ParseResponse::getInt(const char* key) {
-  read();
-  return ParseUtils::getIntFromJSON(buf, key);
-}
-
-double ParseResponse::getDouble(const char* key) {
-  read();
-  return ParseUtils::getFloatFromJSON(buf, key);
-}
-
-bool ParseResponse::getBoolean(const char* key) {
-  read();
-  return ParseUtils::getBooleanFromJSON(buf, key);
-}
-
-void ParseResponse::readWithTimeout(int maxSec) {
-  while((!available()) && (maxSec--)) { // wait till response
-    delay(1000);
-  }
-  read();
-}
-
-bool ParseResponse::nextObject(){
-  if(resultCount <= 0) {
-    count();
-  }
-
-  if(resultCount <= 0) {
-    return false;
-  }
-
-  client->write('n');
-  // reset buffer and read next object
-  p = 0;
-  memset(buf, 0, bufSize);
-  readWithTimeout(5);
-
-  if (*buf) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
-int ParseResponse::count() {
-  client->write('c');
-
-  // reset buffer and read count
-  p = 0;
-  memset(buf, 0, bufSize);
-  readWithTimeout(30);
-  read();
-
-  String c = buf;
-  int count = c.toInt();
-  resultCount = count;
-  return count;
-}
-
-void  ParseResponse::freeBuffer() {
-  if (!isUserBuffer && buf) { // only free non-user buffer
-    delete[] buf;
+ParseResponse::ParseResponse(Process *client)
+{
+    p = 0;
     buf = NULL;
-  }
-  if (tmpBuf) {
-    delete[] tmpBuf;
     tmpBuf = NULL;
-  }
+    bufSize = 0;
+    isUserBuffer = false;
+    this->client = client;
 }
 
-void ParseResponse::close() {
-  if (client && client != &Parse.pushClient) {
-    client->close();
-  }
-  freeBuffer();
+ParseResponse::~ParseResponse()
+{
+    close();
+}
+
+void ParseResponse::setBuffer(char *buffer, int size)
+{
+    if (!buffer || size <= 0)
+    {
+        return;
+    }
+
+    buf = buffer;
+    bufSize = size;
+    isUserBuffer = true;
+    memset(buf, 0, bufSize);
+}
+
+int ParseResponse::available()
+{
+    return client->available();
+}
+
+void ParseResponse::read()
+{
+    if (buf == NULL)
+    {
+        bufSize = BUFSIZE;
+        buf = new char[bufSize];
+    }
+    p += ParsePlatformSupport::read(client, buf + p, bufSize - p);
+}
+
+int ParseResponse::getErrorCode()
+{
+    return getInt("code");
+}
+
+const char *ParseResponse::getJSONBody()
+{
+    read();
+    return buf;
+}
+
+const char *ParseResponse::getString(const char *key)
+{
+    read();
+    if (!tmpBuf)
+    {
+        tmpBuf = new char[64];
+    }
+    memset(tmpBuf, 0, 64);
+    ParseUtils::getStringFromJSON(buf, key, tmpBuf, 64);
+    return tmpBuf;
+}
+
+int ParseResponse::getInt(const char *key)
+{
+    read();
+    return ParseUtils::getIntFromJSON(buf, key);
+}
+
+double ParseResponse::getDouble(const char *key)
+{
+    read();
+    return ParseUtils::getFloatFromJSON(buf, key);
+}
+
+bool ParseResponse::getBoolean(const char *key)
+{
+    read();
+    return ParseUtils::getBooleanFromJSON(buf, key);
+}
+
+void ParseResponse::readWithTimeout(int maxSec)
+{
+    while ((!available()) && (maxSec--))
+    { // wait till response
+        delay(1000);
+    }
+    read();
+}
+
+bool ParseResponse::nextObject()
+{
+    if (resultCount <= 0)
+    {
+        count();
+    }
+
+    if (resultCount <= 0)
+    {
+        return false;
+    }
+
+    client->write('n');
+    // reset buffer and read next object
+    p = 0;
+    memset(buf, 0, bufSize);
+    readWithTimeout(5);
+
+    if (*buf)
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+int ParseResponse::count()
+{
+    client->write('c');
+
+    // reset buffer and read count
+    p = 0;
+    memset(buf, 0, bufSize);
+    readWithTimeout(30);
+    read();
+
+    String c = buf;
+    int count = c.toInt();
+    resultCount = count;
+    return count;
+}
+
+void ParseResponse::freeBuffer()
+{
+    if (!isUserBuffer && buf)
+    { // only free non-user buffer
+        delete[] buf;
+        buf = NULL;
+    }
+    if (tmpBuf)
+    {
+        delete[] tmpBuf;
+        tmpBuf = NULL;
+    }
+}
+
+void ParseResponse::close()
+{
+    if (client && client != &Parse.pushClient)
+    {
+        client->close();
+    }
+    freeBuffer();
 }
 
 #endif

--- a/src/internal/zero/ParseClient.cpp
+++ b/src/internal/zero/ParseClient.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-#if defined (ARDUINO_SAMD_ZERO)
+#if defined(ARDUINO_SAMD_ZERO)
 
 #include "../ParseClient.h"
 #include "../../external/FlashStorage/FlashStorage.h"
@@ -28,17 +28,18 @@
 // Set DEBUG to true to see serial debug output for the main stages
 // of the Parse client.
 const bool DEBUG = false;
-const char* PARSE_API = "api.parse.com";
-const char* USER_AGENT = "arduino-zero.v.1.0.1";
-const char* CLIENT_VERSION = "1.0.3";
-const char* PARSE_PUSH = "push.parse.com";
+const char *PARSE_API = "api.parse.com";
+const char *USER_AGENT = "arduino-zero.v.1.0.1";
+const char *CLIENT_VERSION = "1.0.3";
+const char *PARSE_PUSH = "push.parse.com";
 const unsigned short SSL_PORT = 443;
 
-struct KeysInternalStorage {
-  bool assigned;
-  char installationId[37];
-  char sessionToken[41];
-  char lastPushTime[41];
+struct KeysInternalStorage
+{
+    bool assigned;
+    char installationId[37];
+    char sessionToken[41];
+    char lastPushTime[41];
 };
 
 // Reserve a portion of flash memory to store a "KeysInternalStorage" variable
@@ -50,215 +51,258 @@ FlashStorage(parse_flash_store, KeysInternalStorage);
  * This function does not conform to RFC 4122, even though it returns
  * a string formatted as an UUID. Do not use this to generate proper UUID!
  */
-static String createNewInstallationId(void) {
-  static bool randInitialized = false;
-  char buff[40];
-
-  if (!randInitialized) {
-     struct timeval tm;
-     gettimeofday(&tm, NULL);
-     // Terrible choice for initialization, prone to collision
-     srand((unsigned)tm.tv_sec + (unsigned)tm.tv_usec);
-     randInitialized = true;
-  }
-
-  snprintf(buff, sizeof(buff),
-    "%1x%1x%1x%1x%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x",
-    rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16,
-    rand()%16, rand()%16, rand()%16, rand()%16,
-    rand()%16, rand()%16, rand()%16, rand()%16,
-    rand()%16, rand()%16, rand()%16, rand()%16,
-    rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16, rand()%16
-  );
-  return String(buff);
-}
-
-static void sendAndEchoToSerial(WiFiClient& client, const char *line) {
-  client.print(line);
-  if (Serial && DEBUG)
-    Serial.print(line);
-}
-
-ParseClient::ParseClient() {
-  memset(applicationId, 0, sizeof(applicationId));
-  memset(clientKey, 0, sizeof(clientKey));
-  memset(installationId, 0, sizeof(installationId));
-  memset(sessionToken, 0, sizeof(sessionToken));
-  memset(lastPushTime, 0, sizeof(lastPushTime));
-  lastHeartbeat = 0;
-  dataIsDirty = false;
-}
-
-ParseClient::~ParseClient() {
-  end();
-}
-
-void ParseClient::begin(const char *applicationId, const char *clientKey) {
-  if (Serial && DEBUG) {
-    Serial.print("begin(");
-    Serial.print(applicationId ? applicationId : "NULL");
-    Serial.print(", ");
-    Serial.print(clientKey ? clientKey : "NULL");
-    Serial.println(")");
-  }
-
-  if(applicationId) {
-    strncpy(this->applicationId, applicationId, sizeof(this->applicationId));
-  }
-  if (clientKey) {
-    strncpy(this->clientKey, clientKey, sizeof(this->clientKey));
-  }
-  restoreKeys();
-}
-
-void ParseClient::setInstallationId(const char *installationId) {
-  if (installationId) {
-    if (strcmp(this->installationId, installationId))
-      dataIsDirty = true;
-    strncpy(this->installationId, installationId, sizeof(this->installationId));
-  } else {
-    if (this->installationId[0])
-      dataIsDirty = true;
-    strncpy(this->installationId, "", sizeof(this->installationId));
-  }
-}
-
-const char* ParseClient::getInstallationId() {
-  if (!strlen(installationId)) {
-    setInstallationId(createNewInstallationId().c_str());
+static String createNewInstallationId(void)
+{
+    static bool randInitialized = false;
     char buff[40];
 
-    if (Serial && DEBUG) {
-      Serial.print("creating new installationId:");
-      Serial.println(installationId);
+    if (!randInitialized)
+    {
+        struct timeval tm;
+        gettimeofday(&tm, NULL);
+        // Terrible choice for initialization, prone to collision
+        srand((unsigned)tm.tv_sec + (unsigned)tm.tv_usec);
+        randInitialized = true;
     }
 
-    char content[120];
-    snprintf(content, sizeof(content), "{\"installationId\": \"%s\", \"deviceType\": \"embedded\", \"parseVersion\": \"1.0.0\"}", installationId);
-
-    ParseResponse response = sendRequest("POST", "/1/installations", content, "");
-    if (Serial && DEBUG) {
-      Serial.print("response:");
-      Serial.println(response.getJSONBody());
-    }
-  }
-  saveKeys();
-  return installationId;
+    snprintf(buff, sizeof(buff),
+             "%1x%1x%1x%1x%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x-%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x%1x",
+             rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16,
+             rand() % 16, rand() % 16, rand() % 16, rand() % 16,
+             rand() % 16, rand() % 16, rand() % 16, rand() % 16,
+             rand() % 16, rand() % 16, rand() % 16, rand() % 16,
+             rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16, rand() % 16);
+    return String(buff);
 }
 
-void ParseClient::setSessionToken(const char *sessionToken) {
-  if ((sessionToken != NULL) && (strlen(sessionToken) > 0 )) {
-    if (strcmp(this->sessionToken, sessionToken))
-      dataIsDirty = true;
-    strncpy(this->sessionToken, sessionToken, sizeof(this->sessionToken));
-    if (Serial && DEBUG) {
-      Serial.print("setting the session for installation:");
-      Serial.println(installationId);
-    }
-    getInstallationId();
-    ParseResponse response = sendRequest("GET", "/1/sessions/me", "", "");
-    String installation = response.getString("installationId");
-    if (!installation.length() && strlen(installationId)) {
-      sendRequest("PUT", "/1/sessions/me", "{}\r\n", "");
-    }
-  } else {
-    if (sessionToken[0])
-      dataIsDirty = true;
-   this->sessionToken[0] = 0;
-  }
-}
-
-void ParseClient::clearSessionToken() {
-  setSessionToken(NULL);
-}
-
-const char* ParseClient::getSessionToken() {
-  if (!strlen(sessionToken))
-    return NULL;
-  return sessionToken;
-}
-
-ParseResponse ParseClient::sendRequest(const char* httpVerb, const char* httpPath, const char* requestBody, const char* urlParams) {
-  return sendRequest(String(httpVerb), String(httpPath), String(requestBody), String(urlParams));
-}
-
-ParseResponse ParseClient::sendRequest(const String& httpVerb, const String& httpPath, const String& requestBody, const String& urlParams) {
-  char buff[91] = {0};
-  client.stop();
-
-  saveKeys();
-
-  if (Serial && DEBUG) {
-    Serial.print("sendRequest(\"");
-    Serial.print(httpVerb.c_str());
-    Serial.print("\", \"");
-    Serial.print(httpPath.c_str());
-    Serial.print("\", \"");
-    Serial.print(requestBody.c_str());
-    Serial.print("\", \"");
-    Serial.print(urlParams.c_str());
-    Serial.println("\")");
-  }
-
-  int retry = 3;
-  bool connected;
-
-  while(!(connected = client.connectSSL(PARSE_API, SSL_PORT)) && retry--);
-
-  if (connected) {
-    if (Serial && DEBUG) {
-      Serial.println("connected to server");
-      Serial.println(applicationId);
-      Serial.println(clientKey);
-      Serial.println(installationId);
-    }
-    if (urlParams.length() > 0) {
-        snprintf(buff, sizeof(buff) - 1, "%s %s?%s HTTP/1.1\r\n", httpVerb.c_str(), httpPath.c_str(), urlParams.c_str());
-    } else {
-        snprintf(buff, sizeof(buff) - 1, "%s %s HTTP/1.1\r\n", httpVerb.c_str(), httpPath.c_str());
-    }
-    sendAndEchoToSerial(client, buff);
-    snprintf(buff, sizeof(buff) - 1, "Host: %s\r\n",  PARSE_API);
-    sendAndEchoToSerial(client, buff);
-    snprintf(buff, sizeof(buff) - 1, "X-Parse-Client-Version: %s\r\n", CLIENT_VERSION);
-    sendAndEchoToSerial(client, buff);
-    snprintf(buff, sizeof(buff) - 1, "X-Parse-Application-Id: %s\r\n", applicationId);
-    sendAndEchoToSerial(client, buff);
-    snprintf(buff, sizeof(buff) - 1, "X-Parse-Client-Key: %s\r\n", clientKey);
-    sendAndEchoToSerial(client, buff);
-
-    if (strlen(installationId) > 0) {
-      snprintf(buff, sizeof(buff) - 1, "X-Parse-Installation-Id: %s\r\n", installationId);
-      sendAndEchoToSerial(client, buff);
-    }
-    if (strlen(sessionToken) > 0) {
-      snprintf(buff, sizeof(buff) - 1, "X-Parse-Session-Token: %s\r\n", sessionToken);
-      sendAndEchoToSerial(client, buff);
-    }
-    if (requestBody.length() > 0 && httpVerb != "GET") {
-      requestBody;
-      sendAndEchoToSerial(client, "Content-Type: application/json; charset=utf-8\r\n");
-    } else if (urlParams.length() > 0) {
-      sendAndEchoToSerial(client, "Content-Type: html/text\r\n");
-    }
-    if (requestBody.length() > 0 && httpVerb != "GET") {
-      snprintf(buff, sizeof(buff) - 1, "Content-Length: %d\r\n", requestBody.length());
-      sendAndEchoToSerial(client, buff);
-    }
-    sendAndEchoToSerial(client, "Connection: close\r\n");
-    sendAndEchoToSerial(client, "\r\n");
-    if (requestBody.length() > 0) {
-      sendAndEchoToSerial(client, requestBody.c_str());
-    }
-  } else {
+static void sendAndEchoToSerial(WiFiClient &client, const char *line)
+{
+    client.print(line);
     if (Serial && DEBUG)
-      Serial.println("failed to connect to server");
-  }
-  ParseResponse response(&client);
-  return response;
+        Serial.print(line);
 }
 
-bool ParseClient::startPushService() {
+ParseClient::ParseClient()
+{
+    memset(applicationId, 0, sizeof(applicationId));
+    memset(clientKey, 0, sizeof(clientKey));
+    memset(installationId, 0, sizeof(installationId));
+    memset(sessionToken, 0, sizeof(sessionToken));
+    memset(lastPushTime, 0, sizeof(lastPushTime));
+    lastHeartbeat = 0;
+    dataIsDirty = false;
+}
+
+ParseClient::~ParseClient()
+{
+    end();
+}
+
+void ParseClient::begin(const char *applicationId, const char *clientKey)
+{
+    if (Serial && DEBUG)
+    {
+        Serial.print("begin(");
+        Serial.print(applicationId ? applicationId : "NULL");
+        Serial.print(", ");
+        Serial.print(clientKey ? clientKey : "NULL");
+        Serial.println(")");
+    }
+
+    if (applicationId)
+    {
+        strncpy(this->applicationId, applicationId, sizeof(this->applicationId));
+    }
+    if (clientKey)
+    {
+        strncpy(this->clientKey, clientKey, sizeof(this->clientKey));
+    }
+    restoreKeys();
+}
+
+void ParseClient::setInstallationId(const char *installationId)
+{
+    if (installationId)
+    {
+        if (strcmp(this->installationId, installationId))
+            dataIsDirty = true;
+        strncpy(this->installationId, installationId, sizeof(this->installationId));
+    }
+    else
+    {
+        if (this->installationId[0])
+            dataIsDirty = true;
+        strncpy(this->installationId, "", sizeof(this->installationId));
+    }
+}
+
+const char *ParseClient::getInstallationId()
+{
+    if (!strlen(installationId))
+    {
+        setInstallationId(createNewInstallationId().c_str());
+        char buff[40];
+
+        if (Serial && DEBUG)
+        {
+            Serial.print("creating new installationId:");
+            Serial.println(installationId);
+        }
+
+        char content[120];
+        snprintf(content, sizeof(content), "{\"installationId\": \"%s\", \"deviceType\": \"embedded\", \"parseVersion\": \"1.0.0\"}", installationId);
+
+        ParseResponse response = sendRequest("POST", "/1/installations", content, "");
+        if (Serial && DEBUG)
+        {
+            Serial.print("response:");
+            Serial.println(response.getJSONBody());
+        }
+    }
+    saveKeys();
+    return installationId;
+}
+
+void ParseClient::setSessionToken(const char *sessionToken)
+{
+    if ((sessionToken != NULL) && (strlen(sessionToken) > 0))
+    {
+        if (strcmp(this->sessionToken, sessionToken))
+            dataIsDirty = true;
+        strncpy(this->sessionToken, sessionToken, sizeof(this->sessionToken));
+        if (Serial && DEBUG)
+        {
+            Serial.print("setting the session for installation:");
+            Serial.println(installationId);
+        }
+        getInstallationId();
+        ParseResponse response = sendRequest("GET", "/1/sessions/me", "", "");
+        String installation = response.getString("installationId");
+        if (!installation.length() && strlen(installationId))
+        {
+            sendRequest("PUT", "/1/sessions/me", "{}\r\n", "");
+        }
+    }
+    else
+    {
+        if (sessionToken[0])
+            dataIsDirty = true;
+        this->sessionToken[0] = 0;
+    }
+}
+
+void ParseClient::clearSessionToken()
+{
+    setSessionToken(NULL);
+}
+
+const char *ParseClient::getSessionToken()
+{
+    if (!strlen(sessionToken))
+        return NULL;
+    return sessionToken;
+}
+
+ParseResponse ParseClient::sendRequest(const char *httpVerb, const char *httpPath, const char *requestBody, const char *urlParams)
+{
+    return sendRequest(String(httpVerb), String(httpPath), String(requestBody), String(urlParams));
+}
+
+ParseResponse ParseClient::sendRequest(const String &httpVerb, const String &httpPath, const String &requestBody, const String &urlParams)
+{
+    char buff[91] = {0};
+    client.stop();
+
+    saveKeys();
+
+    if (Serial && DEBUG)
+    {
+        Serial.print("sendRequest(\"");
+        Serial.print(httpVerb.c_str());
+        Serial.print("\", \"");
+        Serial.print(httpPath.c_str());
+        Serial.print("\", \"");
+        Serial.print(requestBody.c_str());
+        Serial.print("\", \"");
+        Serial.print(urlParams.c_str());
+        Serial.println("\")");
+    }
+
+    int retry = 3;
+    bool connected;
+
+    while (!(connected = client.connectSSL(PARSE_API, SSL_PORT)) && retry--)
+        ;
+
+    if (connected)
+    {
+        if (Serial && DEBUG)
+        {
+            Serial.println("connected to server");
+            Serial.println(applicationId);
+            Serial.println(clientKey);
+            Serial.println(installationId);
+        }
+        if (urlParams.length() > 0)
+        {
+            snprintf(buff, sizeof(buff) - 1, "%s %s?%s HTTP/1.1\r\n", httpVerb.c_str(), httpPath.c_str(), urlParams.c_str());
+        }
+        else
+        {
+            snprintf(buff, sizeof(buff) - 1, "%s %s HTTP/1.1\r\n", httpVerb.c_str(), httpPath.c_str());
+        }
+        sendAndEchoToSerial(client, buff);
+        snprintf(buff, sizeof(buff) - 1, "Host: %s\r\n", PARSE_API);
+        sendAndEchoToSerial(client, buff);
+        snprintf(buff, sizeof(buff) - 1, "X-Parse-Client-Version: %s\r\n", CLIENT_VERSION);
+        sendAndEchoToSerial(client, buff);
+        snprintf(buff, sizeof(buff) - 1, "X-Parse-Application-Id: %s\r\n", applicationId);
+        sendAndEchoToSerial(client, buff);
+        snprintf(buff, sizeof(buff) - 1, "X-Parse-Client-Key: %s\r\n", clientKey);
+        sendAndEchoToSerial(client, buff);
+
+        if (strlen(installationId) > 0)
+        {
+            snprintf(buff, sizeof(buff) - 1, "X-Parse-Installation-Id: %s\r\n", installationId);
+            sendAndEchoToSerial(client, buff);
+        }
+        if (strlen(sessionToken) > 0)
+        {
+            snprintf(buff, sizeof(buff) - 1, "X-Parse-Session-Token: %s\r\n", sessionToken);
+            sendAndEchoToSerial(client, buff);
+        }
+        if (requestBody.length() > 0 && httpVerb != "GET")
+        {
+            requestBody;
+            sendAndEchoToSerial(client, "Content-Type: application/json; charset=utf-8\r\n");
+        }
+        else if (urlParams.length() > 0)
+        {
+            sendAndEchoToSerial(client, "Content-Type: html/text\r\n");
+        }
+        if (requestBody.length() > 0 && httpVerb != "GET")
+        {
+            snprintf(buff, sizeof(buff) - 1, "Content-Length: %d\r\n", requestBody.length());
+            sendAndEchoToSerial(client, buff);
+        }
+        sendAndEchoToSerial(client, "Connection: close\r\n");
+        sendAndEchoToSerial(client, "\r\n");
+        if (requestBody.length() > 0)
+        {
+            sendAndEchoToSerial(client, requestBody.c_str());
+        }
+    }
+    else
+    {
+        if (Serial && DEBUG)
+            Serial.println("failed to connect to server");
+    }
+    ParseResponse response(&client);
+    return response;
+}
+
+bool ParseClient::startPushService()
+{
     pushClient.stop();
 
     saveKeys();
@@ -269,120 +313,152 @@ bool ParseClient::startPushService() {
     int retry = 3;
     bool connected;
 
-    while(!(connected = pushClient.connectSSL(PARSE_PUSH, SSL_PORT)) && retry--);
+    while (!(connected = pushClient.connectSSL(PARSE_PUSH, SSL_PORT)) && retry--)
+        ;
 
-    if (connected) {
+    if (connected)
+    {
         if (Serial && DEBUG)
             Serial.println("push started");
-            char buff[256] = {0};
-            snprintf(buff, sizeof(buff),
-                "{\"installation_id\":\"%s\", \"oauth_key\":\"%s\", "
-                "\"v\":\"e1.0.0\", \"last\":%s%s%s}\r\n{}\r\n",
-                installationId,
-                applicationId,
-                lastPushTime[0] ? "\"" : "",
-                lastPushTime[0] ? lastPushTime : "null",
-                lastPushTime[0] ? "\"" : "");
-            sendAndEchoToSerial(pushClient, buff);
-        } else {
+        char buff[256] = {0};
+        snprintf(buff, sizeof(buff),
+                 "{\"installation_id\":\"%s\", \"oauth_key\":\"%s\", "
+                 "\"v\":\"e1.0.0\", \"last\":%s%s%s}\r\n{}\r\n",
+                 installationId,
+                 applicationId,
+                 lastPushTime[0] ? "\"" : "",
+                 lastPushTime[0] ? lastPushTime : "null",
+                 lastPushTime[0] ? "\"" : "");
+        sendAndEchoToSerial(pushClient, buff);
+    }
+    else
+    {
         if (Serial && DEBUG)
             Serial.println("failed to connect to push server");
     }
 }
 
-ParsePush ParseClient::nextPush() {
-  ParsePush push(&pushClient);
-  if (pushBuff[0]) {
-    push.setLookahead(pushBuff);
-    memset(pushBuff, 0, sizeof(pushBuff));
-  }
-  return push;
-}
-
-bool ParseClient::pushAvailable() {
-  bool available = (pushClient.available() > 0);
-  // send keepalive if connected.
-  if (!available && pushClient.connected() && millis() - lastHeartbeat > 1000 * 60 * 12) {
-    pushClient.println("{}");
-    lastHeartbeat = millis();
-  }
-  if (pushBuff[0]) {
-    available = true;
-  } else {
-    for (int i = 0; i < sizeof(pushBuff) && (pushClient.available() > 0); ++i) {
-      pushBuff[i] = pushClient.read();
-    }
-    if (!strncmp(pushBuff, "{}", 2)) {
-      int i = 2;
-      for (; pushBuff[i] == '\r' || pushBuff[i] == '\n'; ++i);
-      if (pushBuff[i]) {
-        int j = i;;
-        for (; pushBuff[i]; ++i)
-          pushBuff[i - j] = pushBuff[i];
-        pushBuff[i - j] = 0;
-      } else {
+ParsePush ParseClient::nextPush()
+{
+    ParsePush push(&pushClient);
+    if (pushBuff[0])
+    {
+        push.setLookahead(pushBuff);
         memset(pushBuff, 0, sizeof(pushBuff));
-        available = (pushClient.available() > 0);
-      }
     }
-  }
-  return available;
+    return push;
 }
 
-void ParseClient::stopPushService() {
-  pushClient.stop();
+bool ParseClient::pushAvailable()
+{
+    bool available = (pushClient.available() > 0);
+    // send keepalive if connected.
+    if (!available && pushClient.connected() && millis() - lastHeartbeat > 1000 * 60 * 12)
+    {
+        pushClient.println("{}");
+        lastHeartbeat = millis();
+    }
+    if (pushBuff[0])
+    {
+        available = true;
+    }
+    else
+    {
+        for (int i = 0; i < sizeof(pushBuff) && (pushClient.available() > 0); ++i)
+        {
+            pushBuff[i] = pushClient.read();
+        }
+        if (!strncmp(pushBuff, "{}", 2))
+        {
+            int i = 2;
+            for (; pushBuff[i] == '\r' || pushBuff[i] == '\n'; ++i)
+                ;
+            if (pushBuff[i])
+            {
+                int j = i;
+                ;
+                for (; pushBuff[i]; ++i)
+                    pushBuff[i - j] = pushBuff[i];
+                pushBuff[i - j] = 0;
+            }
+            else
+            {
+                memset(pushBuff, 0, sizeof(pushBuff));
+                available = (pushClient.available() > 0);
+            }
+        }
+    }
+    return available;
 }
 
-void ParseClient::end() {
-  stopPushService();
+void ParseClient::stopPushService()
+{
+    pushClient.stop();
 }
 
-void ParseClient::saveKeys() {
-  if (dataIsDirty) {
+void ParseClient::end()
+{
+    stopPushService();
+}
+
+void ParseClient::saveKeys()
+{
+    if (dataIsDirty)
+    {
+        KeysInternalStorage stored_keys = parse_flash_store.read();
+
+        stored_keys.assigned = true;
+        strcpy(stored_keys.installationId, installationId);
+        strcpy(stored_keys.sessionToken, sessionToken);
+        strcpy(stored_keys.lastPushTime, lastPushTime);
+        parse_flash_store.write(stored_keys);
+        if (Serial && DEBUG)
+        {
+            Serial.println("ParseClient::saveKeys() : done.");
+        }
+        dataIsDirty = false;
+    }
+    else
+    {
+        if (Serial && DEBUG)
+        {
+            Serial.println("ParseClient::saveKeys() : keys are not changed - skipping...");
+        }
+    }
+}
+
+void ParseClient::restoreKeys()
+{
     KeysInternalStorage stored_keys = parse_flash_store.read();
 
-    stored_keys.assigned = true;
-    strcpy(stored_keys.installationId, installationId);
-    strcpy(stored_keys.sessionToken, sessionToken);
-    strcpy(stored_keys.lastPushTime, lastPushTime);
-    parse_flash_store.write(stored_keys);
-    if (Serial && DEBUG) {
-      Serial.println("ParseClient::saveKeys() : done.");
+    if (stored_keys.assigned)
+    {
+        strcpy(installationId, stored_keys.installationId);
+        strcpy(sessionToken, stored_keys.sessionToken);
+        strcpy(lastPushTime, stored_keys.lastPushTime);
+        if (Serial && DEBUG)
+        {
+            Serial.println("ParseClient::restoreKeys() : done:");
+            Serial.println(installationId);
+            Serial.println(sessionToken);
+            Serial.println(lastPushTime);
+        }
     }
-    dataIsDirty = false;
-  } else {
-    if (Serial && DEBUG) {
-      Serial.println("ParseClient::saveKeys() : keys are not changed - skipping...");
+    else
+    {
+        if (Serial && DEBUG)
+        {
+            Serial.println("ParseClient::restoreKeys() : nothing is stored.");
+        }
     }
-  }
 }
 
-void ParseClient::restoreKeys() {
-  KeysInternalStorage stored_keys = parse_flash_store.read();
-
-  if (stored_keys.assigned) {
-    strcpy(installationId, stored_keys.installationId);
-    strcpy(sessionToken, stored_keys.sessionToken);
-    strcpy(lastPushTime, stored_keys.lastPushTime);
-    if (Serial && DEBUG) {
-      Serial.println("ParseClient::restoreKeys() : done:");
-      Serial.println(installationId);
-      Serial.println(sessionToken);
-      Serial.println(lastPushTime);
-    }
-  } else {
-    if (Serial && DEBUG) {
-      Serial.println("ParseClient::restoreKeys() : nothing is stored.");
-    }
-  }
+void ParseClient::saveLastPushTime(char *time)
+{
+    dataIsDirty = true;
+    strcpy(lastPushTime, time);
+    saveKeys();
 }
-
-void ParseClient::saveLastPushTime(char *time) {
-  dataIsDirty = true;
-  strcpy(lastPushTime, time);
-  saveKeys();
-}
-
 
 ParseClient Parse;
 

--- a/src/internal/zero/ParsePush.cpp
+++ b/src/internal/zero/ParsePush.cpp
@@ -19,35 +19,42 @@
  *
  */
 
-#if defined (ARDUINO_SAMD_ZERO)
+#if defined(ARDUINO_SAMD_ZERO)
 
 #include "../ParsePush.h"
 #include "../ParseClient.h"
 #include "../ParseUtils.h"
 
-ParsePush::ParsePush(WiFiClient* pushClient) : ParseResponse(pushClient) {
+ParsePush::ParsePush(WiFiClient *pushClient) : ParseResponse(pushClient)
+{
     memset(lookahead, 0, sizeof(lookahead));
 }
 
-void ParsePush::close() {
+void ParsePush::close()
+{
     freeBuffer();
 }
 
-void ParsePush::setLookahead(const char *read_data) {
+void ParsePush::setLookahead(const char *read_data)
+{
     strncpy(lookahead, read_data, sizeof(lookahead));
 }
 
-void ParsePush::read() {
-    if (buf == NULL) {
+void ParsePush::read()
+{
+    if (buf == NULL)
+    {
         bufSize = BUFSIZE;
         buf = new char[bufSize];
     }
 
-    if (p == bufSize - 1) {
+    if (p == bufSize - 1)
+    {
         return;
     }
 
-    if (p == 0) {
+    if (p == 0)
+    {
         memset(buf, 0, bufSize);
         for (; lookahead[p]; ++p)
             buf[p] = lookahead[p];
@@ -55,23 +62,28 @@ void ParsePush::read() {
     }
 
     char c;
-    while (client->connected()) {
-        if (client->available()) {
+    while (client->connected())
+    {
+        if (client->available())
+        {
             c = client->read();
-            if (c == '\n') c = '\0';
-            if (p < bufSize - 1) {
+            if (c == '\n')
+                c = '\0';
+            if (p < bufSize - 1)
+            {
                 *(buf + p) = c;
                 p++;
             }
-            if (c == '\0') break;
+            if (c == '\0')
+                break;
         }
     }
     p = 0;
     char time[41];
-    if (ParseUtils::getStringFromJSON(buf, "time", time, sizeof(time))) {
-      Parse.saveLastPushTime(time);
+    if (ParseUtils::getStringFromJSON(buf, "time", time, sizeof(time)))
+    {
+        Parse.saveLastPushTime(time);
     }
 }
 
 #endif // ARDUINO_SAMD_ZERO
-

--- a/src/internal/zero/ParseResponse.cpp
+++ b/src/internal/zero/ParseResponse.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-#if defined (ARDUINO_SAMD_ZERO)
+#if defined(ARDUINO_SAMD_ZERO)
 
 #include "../ParseResponse.h"
 #include "../ParseInternal.h"
@@ -36,412 +36,482 @@ static const int kBufferSize = 1024;
 // Uncomment following line if you want to debug query response with serial output.
 // #define DEBUG_RESPONSE
 
-ParseResponse::ParseResponse(ConnectionClient* client) {
-  buf = NULL;
-  tmpBuf = NULL;
-  p = 0;
-  resultCount = -1;
-  bufSize = 0;
-  isUserBuffer = false;
-  isChunked = false;
-  responseLength = 0;
-  dataDone = false;
-  this->client = client;
-  bufferPos = kBufferSize;
-  lastRead = -1;
+ParseResponse::ParseResponse(ConnectionClient *client)
+{
+    buf = NULL;
+    tmpBuf = NULL;
+    p = 0;
+    resultCount = -1;
+    bufSize = 0;
+    isUserBuffer = false;
+    isChunked = false;
+    responseLength = 0;
+    dataDone = false;
+    this->client = client;
+    bufferPos = kBufferSize;
+    lastRead = -1;
 }
 
-ParseResponse::~ParseResponse() {
-  close();
+ParseResponse::~ParseResponse()
+{
+    close();
 }
 
-void ParseResponse::setBuffer(char* buffer, int size) {
-  if (!buffer || size <= 0) {
-    return;
-  }
+void ParseResponse::setBuffer(char *buffer, int size)
+{
+    if (!buffer || size <= 0)
+    {
+        return;
+    }
 
-  buf = buffer;
-  bufSize = size;
-  isUserBuffer = true;
-  memset(buf, 0, bufSize);
-}
-
-int ParseResponse::available() {
-  return client->available();
-}
-
-void ParseResponse::read() {
-  if (dataDone)
-    return;
-  if (buf == NULL) {
-    bufSize = BUFSIZE;
-    buf = new char[bufSize];
+    buf = buffer;
+    bufSize = size;
+    isUserBuffer = true;
     memset(buf, 0, bufSize);
-  }
+}
 
-  if (p == bufSize - 1) {
-    return;
-  }
+int ParseResponse::available()
+{
+    return client->available();
+}
 
-  memset(buf + p, 0, bufSize - p);
+void ParseResponse::read()
+{
+    if (dataDone)
+        return;
+    if (buf == NULL)
+    {
+        bufSize = BUFSIZE;
+        buf = new char[bufSize];
+        memset(buf, 0, bufSize);
+    }
 
-  char c;
-  int i;
+    if (p == bufSize - 1)
+    {
+        return;
+    }
 
-  bool data = false;
-  int count = 0;
+    memset(buf + p, 0, bufSize - p);
 
-  while (client->connected()) {
-    delay(1);
-    while (client->available()) {
-      c = client->read();
-      if (c != '\r') { // filter out '\r' character
-        if (data) {
-          if (p < bufSize - 1) {
-            *(buf + p) = c;
-            p++;
-          }
+    char c;
+    int i;
+
+    bool data = false;
+    int count = 0;
+
+    while (client->connected())
+    {
+        delay(1);
+        while (client->available())
+        {
+            c = client->read();
+            if (c != '\r')
+            { // filter out '\r' character
+                if (data)
+                {
+                    if (p < bufSize - 1)
+                    {
+                        *(buf + p) = c;
+                        p++;
+                    }
+                }
+                // filter out the headers
+                if (c == '\n')
+                    count++;
+                else
+                    count = 0;
+                if (count >= 2)
+                    data = true;
+            }
         }
-        // filter out the headers
-        if (c == '\n') count++; else count = 0;
-        if (count >= 2) data = true;
-      }
     }
-  }
-  dataDone = 1;
+    dataDone = 1;
 }
 
-void ParseResponse::readLine(char *buff, int sz) {
-  memset(buff, 0, sz);
+void ParseResponse::readLine(char *buff, int sz)
+{
+    memset(buff, 0, sz);
 #ifdef DEBUG_RESPONSE
-  Serial.print("Read line:");
+    Serial.print("Read line:");
 #endif
-  for (int i = 0; client->available(); ++i) {
-    char c = client->read();
-    if (c == '\r') {
-      client->read(); // read /n
-      return;
-    }
-    if (c == '\n') {
-      return;
-    }
+    for (int i = 0; client->available(); ++i)
+    {
+        char c = client->read();
+        if (c == '\r')
+        {
+            client->read(); // read /n
+            return;
+        }
+        if (c == '\n')
+        {
+            return;
+        }
 #ifdef DEBUG_RESPONSE
-    Serial.print(c);
+        Serial.print(c);
 #endif
-    if (i < sz - 1)
-      buff[i] = c;
-  }
+        if (i < sz - 1)
+            buff[i] = c;
+    }
 #ifdef DEBUG_RESPONSE
-  Serial.println("");
+    Serial.println("");
 #endif
 }
 
-bool ParseResponse::readJson(char *buff, int sz) {
-  memset(buff, 0, sz);
+bool ParseResponse::readJson(char *buff, int sz)
+{
+    memset(buff, 0, sz);
 
-  int read_bytes = 0;
+    int read_bytes = 0;
 
-  bool res = readJsonInternal(buff, sz, &read_bytes, '\0');
-  if (!res) {
+    bool res = readJsonInternal(buff, sz, &read_bytes, '\0');
+    if (!res)
+    {
 #ifdef DEBUG_RESPONSE
-    Serial.print("Failed");
+        Serial.print("Failed");
+        Serial.println(buff);
+#endif
+    }
+    return res;
+}
+
+bool ParseResponse::readJsonInternal(char *buff, int sz, int *read_bytes, char started)
+{
+    // It is our own JSON, so we can be *very* strict in regars to format.
+    char in_string = '\0';
+    int ch;
+    int i;
+
+    char tmp[32];
+
+    for (i = 0;; ++i)
+    {
+        bool skip = false;
+        if ((ch = readChunkedData(kQueryTimeout)) < 0)
+        {
+            *read_bytes = i;
+            return false;
+        }
+        switch (ch)
+        {
+        case '\"':
+        case '\'':
+            if (in_string == ch)
+                in_string = '\0';
+            else if (in_string == '\0')
+                in_string = ch;
+            break;
+        case ',':
+            if (in_string)
+                break;
+            if (!started)
+            {
+                --i; // skip
+                skip = true;
+            }
+            break;
+        case '[':
+        case '{':
+        {
+            if (in_string)
+                break;
+            if (!started)
+            {
+                started = ch;
+                break;
+            }
+            int added = 0;
+            if (i < sz)
+                buff[i] = ch;
+            bool success = readJsonInternal(buff + i + 1, sz - i - 1, &added, ch);
+            if (!success)
+                return false;
+            i += added;
+            skip = true;
+        }
+        break;
+        case '}':
+        case ']':
+        {
+            if (in_string)
+                break;
+            if (!started)
+                return false;
+            if ((started == '[' && ch != ']') || (started == '{' && ch != '}'))
+                return false;
+            if (i < sz)
+                buff[i] = ch;
+            *read_bytes = i + 1;
+            return true;
+        }
+        break;
+        }
+        if (!skip && i < sz - 1)
+            buff[i] = ch;
+    }
+}
+
+#ifdef DEBUG_RESPONSE
+void printData(char *d, int sz, int offset)
+{
+    char t1[32];
+    sprintf(t1, "\r\n%d %04x[->", sz, offset);
+    Serial.print(t1);
+    char tmp[4] = {0};
+    for (int i = 0; i < sz; ++i)
+    {
+        if (d[i] >= 32 && d[i] <= 127)
+            tmp[0] = d[i];
+        else
+            tmp[0] = '?';
+        Serial.print(tmp);
+    }
+    Serial.println("<-]");
+}
+#endif
+
+int ParseResponse::readChunkedData(int timeout)
+{
+
+    char snum[16];
+
+    if (bufferPos == kBufferSize || (lastRead > 0 && bufferPos == lastRead))
+    {
+        for (int i = 0; i < timeout && !client->available(); ++i)
+        {
+            delay(1);
+        }
+
+        if (responseLength <= 0)
+        {
+            readLine(snum, sizeof(snum));
+            readLine(snum, sizeof(snum));
+            char *tmp;
+#ifdef DEBUG_RESPONSE
+            Serial.println("");
+            Serial.print("Next chunk:");
+            Serial.println(snum);
+#endif
+            responseLength = strtol(snum, &tmp, 16);
+            if (!responseLength)
+                return -1;
+        }
+        if (client->available())
+        {
+            int to_read = responseLength > kBufferSize ? kBufferSize : responseLength;
+            bufferPos = 0;
+            int sz = client->read((uint8_t *)chunkedBuffer, to_read);
+            lastRead = sz;
+#ifdef DEBUG_RESPONSE
+            Serial.println();
+            Serial.print("Read: ");
+            Serial.println(sz);
+            Serial.println();
+            Serial.print("bufferPos: ");
+            Serial.println(bufferPos);
+            Serial.println();
+            Serial.print("to_read: ");
+            Serial.println(to_read);
+            Serial.println();
+            Serial.print("responseLength: ");
+            Serial.println(responseLength);
+            printData(chunkedBuffer, sz, bufferPos);
+#endif
+            if (sz <= 0)
+                return -1;
+            responseLength -= sz;
+        }
+    }
+    int ch = chunkedBuffer[bufferPos++];
+    return ch;
+}
+
+int ParseResponse::getErrorCode()
+{
+    return getInt("code");
+}
+
+const char *ParseResponse::getJSONBody()
+{
+    read();
+    return buf;
+}
+
+const char *ParseResponse::getString(const char *key)
+{
+    read();
+    if (!tmpBuf)
+    {
+        tmpBuf = new char[64];
+    }
+    memset(tmpBuf, 0, 64);
+    ParseUtils::getStringFromJSON(buf, key, tmpBuf, 64);
+    return tmpBuf;
+}
+
+int ParseResponse::getInt(const char *key)
+{
+    read();
+    return ParseUtils::getIntFromJSON(buf, key);
+}
+
+double ParseResponse::getDouble(const char *key)
+{
+    read();
+    return ParseUtils::getFloatFromJSON(buf, key);
+}
+
+bool ParseResponse::getBoolean(const char *key)
+{
+    read();
+    return ParseUtils::getBooleanFromJSON(buf, key);
+}
+
+void ParseResponse::readWithTimeout(int maxSec)
+{
+    while ((!available()) && (maxSec--))
+    { // wait till response
+        delay(1000);
+    }
+    read();
+}
+
+bool ParseResponse::nextObject()
+{
+    if (resultCount <= 0)
+    {
+        count();
+    }
+
+    if (resultCount <= 0)
+    {
+        return false;
+    }
+
+    if (firstObject)
+    {
+        firstObject = false;
+        return true;
+    }
+    else
+    {
+        return readJson(buf, bufSize);
+    }
+}
+
+int ParseResponse::count()
+{
+    if (resultCount != -1)
+        return resultCount;
+    char buff[128];
+
+    resultCount = 0;
+
+    bool first_line = true;
+    bool ok = false;
+    bool done = false;
+    char *ptr;
+    long len = 0;
+    while (client->connected() && !done)
+    {
+        delay(1);
+        while (client->available())
+        {
+            readLine(buff, sizeof(buff));
+            if (first_line)
+            {
+                if (!strcmp(kHttpOK, buff))
+                    ok = true;
+                first_line = false;
+            }
+#ifdef DEBUG_RESPONSE
+            Serial.print("H->");
+            Serial.println(buff);
+#endif
+            if (!strcmp(kChunkedEncoding, buff))
+            {
+                isChunked = true;
+            }
+            else if (!strncmp(kContentLength, buff, sizeof(kContentLength)))
+            {
+                responseLength = strtol(buff + sizeof(kContentLength), &ptr, 10);
+            }
+            else if (!buff[0])
+            {
+                if (isChunked && client->available())
+                {
+                    readLine(buff, sizeof(buff));
+                    responseLength = strtol(buff, &ptr, 16);
+#ifdef DEBUG_RESPONSE
+                    Serial.print("First chunk->");
+                    Serial.println(buff);
+#endif
+                }
+                done = true;
+                break;
+            }
+        }
+    }
+    long persistentResponseLength = responseLength; // responseLength is modified by calls to readChunkedData
+#ifdef DEBUG_RESPONSE
+    sprintf(buff, "Ok:%s Length:%d Chunked:%s", ok ? "y" : "n", responseLength, isChunked ? "y" : "n");
     Serial.println(buff);
 #endif
-  }
-  return res;
-}
+    done = false;
+    freeBuffer();
+    setBuffer(new char[kJsonResponseMaxSize], kJsonResponseMaxSize);
+    dataDone = true;
 
-bool ParseResponse::readJsonInternal(char *buff, int sz, int* read_bytes, char started) {
-  // It is our own JSON, so we can be *very* strict in regars to format.
-  char in_string = '\0';
-  int ch;
-  int i;
-
-  char tmp[32];
-
-  for (i = 0; ; ++i) {
-    bool skip = false;
-    if ((ch = readChunkedData(kQueryTimeout)) < 0) {
-      *read_bytes = i;
-      return false;
-    }
-    switch (ch) {
-      case '\"':
-      case '\'':
-        if (in_string == ch)
-          in_string = '\0';
-        else if (in_string == '\0')
-          in_string = ch;
-        break;
-      case ',':
-        if (in_string)
-          break;
-        if (!started) {
-          --i; // skip
-          skip = true;
+    for (int i = 0; i < sizeof(kResultsStart) - 1; ++i)
+    {
+        char c = readChunkedData(kQueryTimeout);
+        if (c != kResultsStart[i])
+        {
+#ifdef DEBUG_RESPONSE
+            Serial.println("Malformed response!");
+#endif
+            resultCount = -1;
+            return -1;
         }
-        break;
-      case '[':
-      case '{':
-      {
-        if (in_string)
-          break;
-        if (!started) {
-          started = ch;
-          break;
-        }
-        int added = 0;
-        if (i < sz)
-          buff[i] = ch;
-        bool success = readJsonInternal(buff + i + 1, sz - i - 1, &added, ch);
-        if (!success)
-          return false;
-        i += added;
-        skip = true;
-      } break;
-      case '}':
-      case ']':
-      {
-        if (in_string)
-          break;
-        if (!started)
-          return false;
-        if ((started == '[' && ch != ']') || (started == '{' && ch != '}'))
-          return false;
-        if (i < sz)
-          buff[i] = ch;
-        *read_bytes = i + 1;
-        return true;
-      } break;
     }
-    if (!skip && i < sz - 1)
-      buff[i] = ch;
-  }
-}
 
+    if (!readJson(buf, bufSize))
+    {
 #ifdef DEBUG_RESPONSE
-void printData(char *d, int sz, int offset) {
-  char t1[32];
-  sprintf(t1,"\r\n%d %04x[->", sz, offset);
-  Serial.print(t1);
-  char tmp[4] = {0};
-  for (int i = 0; i < sz; ++i) {
-    if (d[i] >= 32 && d[i] <= 127)
-      tmp[0] = d[i];
-    else
-      tmp[0] = '?';
-    Serial.print(tmp);
-  }
-  Serial.println("<-]");
-}
+        Serial.println("no results");
 #endif
-
-int ParseResponse::readChunkedData(int timeout) {
-
-  char snum[16];
-
-  if (bufferPos == kBufferSize || (lastRead > 0 && bufferPos == lastRead)) {
-    for (int i = 0; i < timeout && !client->available(); ++i) {
-        delay(1);
+        resultCount = 0;
+        return 0;
     }
 
-    if (responseLength <= 0) {
-      readLine(snum, sizeof(snum));
-      readLine(snum, sizeof(snum));
-      char *tmp;
-#ifdef DEBUG_RESPONSE
-      Serial.println("");
-      Serial.print("Next chunk:");
-      Serial.println(snum);
-#endif
-      responseLength = strtol(snum, &tmp, 16); 
-      if (!responseLength)
-        return -1;
-    }
-    if (client->available()) {
-      int to_read = responseLength > kBufferSize ? kBufferSize : responseLength;
-      bufferPos = 0;
-      int sz = client->read((uint8_t *)chunkedBuffer, to_read);
-      lastRead = sz;
-#ifdef DEBUG_RESPONSE
-      Serial.println();
-      Serial.print("Read: ");
-      Serial.println(sz);
-      Serial.println();
-      Serial.print("bufferPos: ");
-      Serial.println(bufferPos);
-      Serial.println();
-      Serial.print("to_read: ");
-      Serial.println(to_read);
-      Serial.println();
-      Serial.print("responseLength: ");
-      Serial.println(responseLength);
-      printData(chunkedBuffer, sz, bufferPos);
-#endif
-      if (sz <= 0)
-        return -1;
-      responseLength -= sz;
-    }
-  }
-  int ch = chunkedBuffer[bufferPos++];
-  return ch;
-}
+    int tmplen = strlen(buf);
+    firstObject = true;
+    if (tmplen > 0)
+        resultCount = persistentResponseLength / tmplen;
+    if (isChunked)
+        resultCount *= 2;
+    if (!resultCount)
+        resultCount = 1;
 
-int ParseResponse::getErrorCode() {
-  return getInt("code");
-}
-
-const char* ParseResponse::getJSONBody() {
-  read();
-  return buf;
-}
-
-const char* ParseResponse::getString(const char* key) {
-  read();
-  if (!tmpBuf) {
-    tmpBuf = new char[64];
-  }
-  memset(tmpBuf, 0, 64);
-  ParseUtils::getStringFromJSON(buf, key, tmpBuf, 64);
-  return tmpBuf;
-}
-
-int ParseResponse::getInt(const char* key) {
-  read();
-  return ParseUtils::getIntFromJSON(buf, key);
-}
-
-double ParseResponse::getDouble(const char* key) {
-  read();
-  return ParseUtils::getFloatFromJSON(buf, key);
-}
-
-bool ParseResponse::getBoolean(const char* key) {
-  read();
-  return ParseUtils::getBooleanFromJSON(buf, key);
-}
-
-void ParseResponse::readWithTimeout(int maxSec) {
-  while((!available()) && (maxSec--)) { // wait till response
-    delay(1000);
-  }
-  read();
-}
-
-bool ParseResponse::nextObject() {
-  if(resultCount <= 0) {
-    count();
-  }
-
-  if(resultCount <= 0) {
-    return false;
-  }
-
-  if (firstObject) {
-    firstObject = false;
-    return true;
-  } else {
-    return readJson(buf, bufSize);
-  }
-}
-
-int ParseResponse::count() {
-  if (resultCount != -1)
     return resultCount;
-  char buff[128];
-
-  resultCount = 0;
-
-  bool first_line = true;
-  bool ok = false;
-  bool done = false;
-  char *ptr;
-  long len = 0;
-  while (client->connected() && !done) {
-    delay(1);
-    while (client->available()) {
-      readLine(buff, sizeof(buff));
-      if (first_line) {
-        if (!strcmp(kHttpOK, buff))
-          ok = true;
-        first_line = false;
-      }
-#ifdef DEBUG_RESPONSE
-      Serial.print("H->");
-      Serial.println(buff);
-#endif
-      if (!strcmp(kChunkedEncoding, buff)) {
-        isChunked = true;
-      } else if (!strncmp(kContentLength, buff, sizeof(kContentLength))) {
-        responseLength = strtol(buff + sizeof(kContentLength), &ptr, 10);
-      } else if (!buff[0]) {
-        if (isChunked && client->available()) {
-          readLine(buff, sizeof(buff));
-          responseLength = strtol(buff, &ptr, 16);
-#ifdef DEBUG_RESPONSE
-          Serial.print("First chunk->");
-          Serial.println(buff);
-#endif
-        }
-        done = true;
-        break;
-      }
-    }
-  }
-  long persistentResponseLength = responseLength; // responseLength is modified by calls to readChunkedData
-#ifdef DEBUG_RESPONSE
-  sprintf(buff, "Ok:%s Length:%d Chunked:%s", ok ? "y" : "n", responseLength, isChunked ? "y" : "n");
-  Serial.println(buff);
-#endif
-  done = false;
-  freeBuffer();
-  setBuffer(new char[kJsonResponseMaxSize], kJsonResponseMaxSize);
-  dataDone = true;
-
-  for (int i = 0; i < sizeof(kResultsStart) - 1; ++i) {
-    char c = readChunkedData(kQueryTimeout);
-    if (c != kResultsStart[i]) {
-#ifdef DEBUG_RESPONSE
-      Serial.println("Malformed response!");
-#endif
-      resultCount = -1;
-      return -1;
-    }
-  }
-
-  if (!readJson(buf, bufSize)) {
-#ifdef DEBUG_RESPONSE
-    Serial.println("no results");
-#endif
-    resultCount = 0;
-    return 0;
-  }
-
-  int tmplen = strlen(buf);
-  firstObject = true;
-  if (tmplen > 0)
-    resultCount = persistentResponseLength / tmplen;
-  if (isChunked)
-    resultCount *= 2;
-  if (!resultCount)
-    resultCount = 1;
-
-  return resultCount;
 }
 
-void ParseResponse::freeBuffer() {
-  if (!isUserBuffer) { // only free non-user buffer
-    delete[] buf;
-    buf = NULL;
-  }
-  if (tmpBuf) {
-    delete[] tmpBuf;
-    tmpBuf = NULL;
-  }
+void ParseResponse::freeBuffer()
+{
+    if (!isUserBuffer)
+    { // only free non-user buffer
+        delete[] buf;
+        buf = NULL;
+    }
+    if (tmpBuf)
+    {
+        delete[] tmpBuf;
+        tmpBuf = NULL;
+    }
 }
 
-void ParseResponse::close() {
-  freeBuffer();
+void ParseResponse::close()
+{
+    freeBuffer();
 }
 
 #endif // ARDUINO_SAMD_ZERO


### PR DESCRIPTION
There were several compile warnings related to unused variables as well as type mismatches.  The first commit fixes that.

The second commit is a nod to my OCD and normalizes the formatting across all of the source files.  I'll understand if you don't merge that.